### PR TITLE
feat: Integrating vnetestbed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format
+      - name: Install clang-format-17
+        run: sudo apt-get update -qq && sudo apt-get install -y clang-format-17
+
+      - name: Alias clang-format
+        run: sudo ln -sf /usr/bin/clang-format-17 /usr/local/bin/clang-format
 
       - name: Check formatting
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ on:
 jobs:
   clang-format:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/include/vertexnova/testbed/imgui/imgui_layer.h
+++ b/include/vertexnova/testbed/imgui/imgui_layer.h
@@ -69,11 +69,7 @@ struct SettingsWindowScreenRect {
 
 /** Collapsed windows keep the title-bar rect; skipped (hidden tab) windows invalidate it. */
 [[nodiscard]] inline SettingsWindowScreenRect makeSettingsWindowScreenRectWhenBeginSkipped(
-    bool window_collapsed,
-    float pos_x,
-    float pos_y,
-    float width,
-    float height) noexcept {
+    bool window_collapsed, float pos_x, float pos_y, float width, float height) noexcept {
     if (!window_collapsed) {
         return {};
     }

--- a/include/vertexnova/testbed/imgui/imgui_layer.h
+++ b/include/vertexnova/testbed/imgui/imgui_layer.h
@@ -231,6 +231,14 @@ class ImGuiLayer : public ILayer {
     /// Viewport window rects in screen space (min_x, min_y, max_x, max_y); updated each frame in renderViewportWindows
     std::vector<float> viewport_rects_;
 
+    /// "Settings" window AABB in ImGui screen space; excludes it from scene viewport hit-testing so dragging sliders
+    /// does not orbit the camera. Updated in renderSettingsPanel().
+    bool settings_window_rect_valid_{false};
+    float settings_screen_min_x_{0.f};
+    float settings_screen_min_y_{0.f};
+    float settings_screen_max_x_{0.f};
+    float settings_screen_max_y_{0.f};
+
 #if defined(VNE_TESTBED_EVENTS)
     std::shared_ptr<ImGuiEventListener> event_listener_;
 #endif

--- a/include/vertexnova/testbed/imgui/imgui_layer.h
+++ b/include/vertexnova/testbed/imgui/imgui_layer.h
@@ -56,6 +56,32 @@ class ImGuiEventListener;
 namespace vne {
 namespace testbed {
 
+namespace detail {
+
+/** Screen-space hit rect for the Settings window when ImGui::Begin returns false. */
+struct SettingsWindowScreenRect {
+    bool valid{false};
+    float min_x{0.f};
+    float min_y{0.f};
+    float max_x{0.f};
+    float max_y{0.f};
+};
+
+/** Collapsed windows keep the title-bar rect; skipped (hidden tab) windows invalidate it. */
+[[nodiscard]] inline SettingsWindowScreenRect makeSettingsWindowScreenRectWhenBeginSkipped(
+    bool window_collapsed,
+    float pos_x,
+    float pos_y,
+    float width,
+    float height) noexcept {
+    if (!window_collapsed) {
+        return {};
+    }
+    return SettingsWindowScreenRect{true, pos_x, pos_y, pos_x + width, pos_y + height};
+}
+
+}  // namespace detail
+
 /**
  * @class ImGuiLayer
  * @brief ImGui overlay with docking, viewports, settings panel, and viewport layout.

--- a/samples/glfw_opengl/00_hello_testbed/demo_hello_testbed.cpp
+++ b/samples/glfw_opengl/00_hello_testbed/demo_hello_testbed.cpp
@@ -60,7 +60,7 @@ void HelloSettingsLayer::setImGuiLayer(vne::testbed::ImGuiLayer* layer) {
 void HelloSettingsLayer::renderPanel() {
     if (ImGui::CollapsingHeader("Viewport", ImGuiTreeNodeFlags_DefaultOpen)) {
         ImGui::TextDisabled("Controls");
-        ImGui::BulletText("Orbit:  Left-mouse drag");
+        ImGui::BulletText("Rotate (trackball):  Left-mouse drag");
         ImGui::BulletText("Pan:    Right-mouse drag");
         ImGui::BulletText("Zoom:   Scroll wheel");
         ImGui::Spacing();
@@ -85,7 +85,7 @@ void registerHelloTestbedDemo(vne::testbed::Application& app) {
     app.getLayerStack().pushLayer(std::unique_ptr<BaseSceneLayer>(scene), app.getAppContext());
 
 #ifdef VNE_TESTBED_INTERACTION
-    // Layer 2: orbit/trackball interaction (per-viewport cameras when using multiple viewports)
+    // Layer 2: trackball inspect interaction (per-viewport cameras when using multiple viewports)
     auto* interaction = new BaseInteractionLayer("HelloInteractionLayer");
     interaction->setSceneLayer(scene);
     app.getLayerStack().pushLayer(std::unique_ptr<BaseInteractionLayer>(interaction), app.getAppContext());

--- a/samples/glfw_opengl/02_test_scene/demo_test_scene.cpp
+++ b/samples/glfw_opengl/02_test_scene/demo_test_scene.cpp
@@ -196,7 +196,8 @@ void SceneTestLayer::onRender(const vne::testbed::RenderContext& render_context)
 
     // Aspect / resize — only update when the viewport size actually changes
     if (render_context.frame_info.width > 0 && render_context.frame_info.height > 0) {
-        if (render_context.frame_info.width != ui_.last_viewport_w || render_context.frame_info.height != ui_.last_viewport_h) {
+        if (render_context.frame_info.width != ui_.last_viewport_w
+            || render_context.frame_info.height != ui_.last_viewport_h) {
             ui_.last_viewport_w = render_context.frame_info.width;
             ui_.last_viewport_h = render_context.frame_info.height;
             updateCameraAspect(ui_.last_viewport_w, ui_.last_viewport_h);
@@ -649,8 +650,9 @@ void SceneTestLayer::drawFrustum(vne::math::Vec3f pos,
     const vne::math::Vec3f far_col{0.3f, 0.8f, 1.0f};   // cyan   — far  plane
     const vne::math::Vec3f edge_col{0.7f, 0.7f, 0.7f};  // gray   — connecting edges
 
-    const float aspect =
-        (ui_.last_viewport_h > 0) ? (static_cast<float>(ui_.last_viewport_w) / static_cast<float>(ui_.last_viewport_h)) : 1.f;
+    const float aspect = (ui_.last_viewport_h > 0)
+                             ? (static_cast<float>(ui_.last_viewport_w) / static_cast<float>(ui_.last_viewport_h))
+                             : 1.f;
 
     if (ui_.use_perspective) {
         // Tangent of half-FOV gives the slope; multiply by distance to get half-extents.

--- a/samples/glfw_opengl/02_test_scene/demo_test_scene.cpp
+++ b/samples/glfw_opengl/02_test_scene/demo_test_scene.cpp
@@ -196,10 +196,10 @@ void SceneTestLayer::onRender(const vne::testbed::RenderContext& render_context)
 
     // Aspect / resize — only update when the viewport size actually changes
     if (render_context.frame_info.width > 0 && render_context.frame_info.height > 0) {
-        if (render_context.frame_info.width != ui_.last_vp_w || render_context.frame_info.height != ui_.last_vp_h) {
-            ui_.last_vp_w = render_context.frame_info.width;
-            ui_.last_vp_h = render_context.frame_info.height;
-            updateCameraAspect(ui_.last_vp_w, ui_.last_vp_h);
+        if (render_context.frame_info.width != ui_.last_viewport_w || render_context.frame_info.height != ui_.last_viewport_h) {
+            ui_.last_viewport_w = render_context.frame_info.width;
+            ui_.last_viewport_h = render_context.frame_info.height;
+            updateCameraAspect(ui_.last_viewport_w, ui_.last_viewport_h);
         }
     }
 
@@ -278,10 +278,10 @@ void SceneTestLayer::onRender(const vne::testbed::RenderContext& render_context)
 
 void SceneTestLayer::rebuildCamera(int w, int h) {
     if (w > 0 && h > 0) {
-        ui_.last_vp_w = w;
-        ui_.last_vp_h = h;
+        ui_.last_viewport_w = w;
+        ui_.last_viewport_h = h;
     }
-    buildCamera(ui_.last_vp_w, ui_.last_vp_h);
+    buildCamera(ui_.last_viewport_w, ui_.last_viewport_h);
 }
 
 void SceneTestLayer::syncCameraPositionTargetUp() {
@@ -413,19 +413,19 @@ void SceneTestLayer::removeLastPointLight() {
 }
 
 void SceneTestLayer::resetToDefault() {
-    const int save_w = ui_.last_vp_w;
-    const int save_h = ui_.last_vp_h;
+    const int save_w = ui_.last_viewport_w;
+    const int save_h = ui_.last_viewport_h;
     // Remove point lights from scene_state_ while ui_.point_lights still lists them.
     // Assigning ui_ first would clear the vector and skip this loop, leaking lights in scene_state_.
     while (!ui_.point_lights.empty()) {
         removeLastPointLight();
     }
     ui_ = SceneUiSettings{};
-    ui_.last_vp_w = save_w;
-    ui_.last_vp_h = save_h;
+    ui_.last_viewport_w = save_w;
+    ui_.last_viewport_h = save_h;
     cube_angle_ = 0.f;
 
-    rebuildCamera(ui_.last_vp_w, ui_.last_vp_h);
+    rebuildCamera(ui_.last_viewport_w, ui_.last_viewport_h);
     syncCameraPositionTargetUp();
     syncAmbientLight();
     syncDirLight();
@@ -650,7 +650,7 @@ void SceneTestLayer::drawFrustum(vne::math::Vec3f pos,
     const vne::math::Vec3f edge_col{0.7f, 0.7f, 0.7f};  // gray   — connecting edges
 
     const float aspect =
-        (ui_.last_vp_h > 0) ? (static_cast<float>(ui_.last_vp_w) / static_cast<float>(ui_.last_vp_h)) : 1.f;
+        (ui_.last_viewport_h > 0) ? (static_cast<float>(ui_.last_viewport_w) / static_cast<float>(ui_.last_viewport_h)) : 1.f;
 
     if (ui_.use_perspective) {
         // Tangent of half-FOV gives the slope; multiply by distance to get half-extents.
@@ -846,7 +846,7 @@ void SceneSettingsLayer::renderPanel() {
             sl.syncCameraPositionTargetUp();
         }
         if (proj_changed) {
-            sl.rebuildCamera(ui.last_vp_w, ui.last_vp_h);
+            sl.rebuildCamera(ui.last_viewport_w, ui.last_viewport_h);
 #ifdef VNE_TESTBED_INTERACTION
             if (interaction_layer_) {
                 interaction_layer_->setCameras(sl.getActiveCameras());

--- a/samples/glfw_opengl/02_test_scene/demo_test_scene.h
+++ b/samples/glfw_opengl/02_test_scene/demo_test_scene.h
@@ -75,8 +75,8 @@ struct SceneUiSettings {
     bool show_frustum{true};                       //!< Wireframe frustum when show_camera_visuals.
     bool show_cam_axes{true};                      //!< Forward/right/up at camera position.
     bool show_near_far_planes{true};               //!< Extra diagonals on near/far rects.
-    int last_vp_w{1280};                           //!< Last known framebuffer width (px); drives aspect.
-    int last_vp_h{720};                            //!< Last known framebuffer height (px).
+    int last_viewport_w{1280};                     //!< Last known framebuffer width (px); drives aspect. Matches BaseSceneLayer::UiSettings naming.
+    int last_viewport_h{720};                      //!< Last known framebuffer height (px).
 
     int cube_count{3};                //!< Number of cubes drawn (0–4); positions are still defined for all four.
     float cube_rotation_speed{0.5f};  //!< Radians per second; shared by all cubes.

--- a/samples/glfw_opengl/02_test_scene/demo_test_scene.h
+++ b/samples/glfw_opengl/02_test_scene/demo_test_scene.h
@@ -75,8 +75,9 @@ struct SceneUiSettings {
     bool show_frustum{true};                       //!< Wireframe frustum when show_camera_visuals.
     bool show_cam_axes{true};                      //!< Forward/right/up at camera position.
     bool show_near_far_planes{true};               //!< Extra diagonals on near/far rects.
-    int last_viewport_w{1280};                     //!< Last known framebuffer width (px); drives aspect. Matches BaseSceneLayer::UiSettings naming.
-    int last_viewport_h{720};                      //!< Last known framebuffer height (px).
+    int last_viewport_w{
+        1280};  //!< Last known framebuffer width (px); drives aspect. Matches BaseSceneLayer::UiSettings naming.
+    int last_viewport_h{720};  //!< Last known framebuffer height (px).
 
     int cube_count{3};                //!< Number of cubes drawn (0–4); positions are still defined for all four.
     float cube_rotation_speed{0.5f};  //!< Radians per second; shared by all cubes.

--- a/samples/glfw_opengl/03_test_interaction/README.md
+++ b/samples/glfw_opengl/03_test_interaction/README.md
@@ -1,13 +1,13 @@
 # 03 - Test Interaction
 
-Full **interaction** demo on top of [`BaseSceneLayer`](../common/base_scene_layer.h): every high-level controller type (Inspect orbit or virtual trackball with Hyperbolic/Rim projection, 3D navigation with FPS/Fly/Game modes, orthographic pan/zoom, follow), zoom methods, view-direction presets, and optional mesh loading from testdata when `VNE_TESTBED_VNEIO` is enabled. It shares the same **build / run / IDE** workflow as [`00_hello_testbed`](../00_hello_testbed/README.md) and uses the same Blinn-Phong [`MeshLayer`](../../../include/vertexnova/testbed/utils/mesh_layer.h) path as the scene samples when meshes are available.
+Full **interaction** demo on top of [`BaseSceneLayer`](../common/base_scene_layer.h): high-level controllers **Inspect 3D** (virtual trackball with Hyperbolic/Rim projection), **Navigation 3D** (FPS / Fly via `FreeLookMode`), **Ortho 2D**, zoom methods, view-direction presets, and optional mesh loading from testdata when `VNE_TESTBED_VNEIO` is enabled. It shares the same **build / run / IDE** workflow as [`00_hello_testbed`](../00_hello_testbed/README.md) and uses the same Blinn-Phong [`MeshLayer`](../../../include/vertexnova/testbed/utils/mesh_layer.h) path as the scene samples when meshes are available.
 
 Screenshots are not included yet; they may be added in a later revision.
 
 ## What This Sample Shows
 
 1. **Base scene**: Grid, axes, perspective or orthographic camera from `BaseSceneLayer`; settings can toggle grid/axes and switch projection.
-2. **Controllers**: Runtime selection among Inspect (Euler orbit or trackball), Navigation (FPS / Fly via `FreeLookMode`), Ortho 2D (`Ortho2DController`), and Follow; per-controller ImGui tuning (trackball projection when in trackball inspect mode, pivot mode, speeds, navigation multipliers, ortho/follow options).
+2. **Controllers**: Runtime selection among Inspect 3D (trackball with Hyperbolic/Rim projection), Navigation (FPS / Fly via `FreeLookMode`), and Ortho 2D (`Ortho2DController`); per-controller ImGui tuning (pivot mode, speeds, navigation multipliers, ortho options).
 3. **Zoom**: Dolly-to-COI, scene-scale, or FOV change where applicable; matrix readouts for view and projection when enabled.
 4. **Mesh browser** (with vneio): Lists mesh files under the configured directory (PLY, OBJ, STL, FBX, glTF), loads on click, drag-and-drop to the viewport, plus lighting and mesh transform panels when a mesh is loaded.
 5. **Layer stack**: `BaseSceneLayer` → `InteractionTestLayer` → optional `MeshLayer` → `InteractionSettingsLayer` (ImGui settings).
@@ -67,7 +67,7 @@ When you built with a script, run the executable under that script’s build dir
 
 ## Key Concepts
 
-- **`ControllerVariant`**: `std::variant` over Inspect, Navigation3D, Ortho2D, and Follow controllers; dispatch uses `std::visit` for resize, events, and updates.
+- **`ControllerVariant`**: `std::variant` over Inspect3D, Navigation3D, and Ortho2D controllers; dispatch uses `std::visit` for resize, events, and updates.
 - **`InteractionTestLayer`**: One controller instance per viewport (up to four), synced with scene cameras from `BaseSceneLayer::getActiveCameras()`.
 - **`InteractionSettingsLayer`**: ImGui panel; UI state is grouped in `InteractionUiSettings` with `uiSettings()` accessors (same idea as [`SceneUiSettings`](../02_test_scene/demo_test_scene.h) in `02_test_scene`).
 - **Optional vneio**: Mesh listing, reload, drag-and-drop, and Phong lighting UI require `VNE_TESTBED_VNEIO` and the vneio-linked `MeshLayer`.

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -147,8 +147,18 @@ void InteractionTestLayer::dispatchEvent(const vne::events::Event& event, int vi
         viewport_index = 0;
     }
     auto& v = controllers_[static_cast<size_t>(viewport_index)];
+
+    // Use the real frame dt for mouse-move/drag events so pan inertia velocity is sampled correctly.
+    // Key-repeat events still use kFixedDt (key hold timing is frame-rate independent).
+    const bool is_mouse_event = (event.type() == vne::events::EventType::eMouseMoved
+                                 || event.type() == vne::events::EventType::eMouseScrolled
+                                 || event.type() == vne::events::EventType::eMouseButtonPressed
+                                 || event.type() == vne::events::EventType::eMouseButtonReleased
+                                 || event.type() == vne::events::EventType::eMouseButtonDoubleClicked);
+    const double event_dt = is_mouse_event ? last_frame_dt_ : kFixedDt;
+
     std::visit(
-        [&event](auto& c) {
+        [&event, event_dt](auto& c) {
             const bool needs_cursor_position = (event.type() == vne::events::EventType::eMouseScrolled
                                                 || event.type() == vne::events::EventType::eMouseButtonPressed
                                                 || event.type() == vne::events::EventType::eMouseButtonReleased
@@ -168,7 +178,7 @@ void InteractionTestLayer::dispatchEvent(const vne::events::Event& event, int vi
             if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Ortho2DController>) {
                 c.onEvent(event);
             } else {
-                c.onEvent(event, kFixedDt);
+                c.onEvent(event, event_dt);
             }
         },
         v);
@@ -204,6 +214,7 @@ void InteractionTestLayer::onAttach(vne::testbed::AppContext& app_context) {
 void InteractionTestLayer::onDetach() {}
 
 void InteractionTestLayer::onUpdate(float dt) {
+    last_frame_dt_ = static_cast<double>(dt > 0.0f ? dt : 1.0f / 60.0f);
 #ifdef VNE_TESTBED_IMGUI
     if (imgui_layer_) {
         for (int i = 0; i < kMaxViewports; ++i) {
@@ -274,6 +285,18 @@ void InteractionTestLayer::onEvent(const vne::events::Event& event) {
 
 void InteractionTestLayer::setControllerKind(ControllerKind kind) {
     current_kind_ = kind;
+
+    // Apply pose-reset before tearing down old controllers so resetCamera still has a camera to reset.
+    if (switch_policy_.reset_pose_to_default) {
+        resetCamera();
+    }
+
+    // Step 1: clear accumulated scene scale so new manipulators syncFromCamera with scale=1.
+    if (camera_ && switch_policy_.reset_scene_scale) {
+        camera_->setSceneScale(1.0f);
+        camera_->updateMatrices();
+    }
+
     const auto vpw = kDefaultViewportW;
     const auto vph = kDefaultViewportH;
     for (size_t i = 0; i < static_cast<size_t>(kMaxViewports); ++i) {
@@ -281,12 +304,17 @@ void InteractionTestLayer::setControllerKind(ControllerKind kind) {
         std::visit(
             [this, vpw, vph](auto& c) {
                 c.onResize(vpw, vph);
-                if (camera_) {
-                    c.setCamera(camera_);
-                }
             },
             controllers_[i]);
     }
+
+    // Step 2: reset rig + mapper state on fresh controllers before attaching camera.
+    if (switch_policy_.reset_rig_state) {
+        dispatchReset();
+    }
+
+    // Step 3: attach camera — triggers syncFromCamera() in each manipulator from a clean scale baseline.
+    dispatchSetCamera(camera_);
 }
 
 void InteractionTestLayer::setZoomMethod(vne::interaction::ZoomMethod method) {
@@ -294,7 +322,7 @@ void InteractionTestLayer::setZoomMethod(vne::interaction::ZoomMethod method) {
         std::visit(
             [method](auto& c) {
                 if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Inspect3DController>) {
-                    c.orbitalCameraManipulator().setZoomMethod(method);
+                    c.trackballManipulator().setZoomMethod(method);
                 } else if constexpr (std::is_same_v<std::decay_t<decltype(c)>,
                                                     vne::interaction::Navigation3DController>) {
                     c.freeLookManipulator().setZoomMethod(method);
@@ -311,7 +339,7 @@ void InteractionTestLayer::setViewDirection(vne::interaction::ViewDirection dir)
         std::visit(
             [dir](auto& c) {
                 if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Inspect3DController>) {
-                    c.orbitalCameraManipulator().setViewDirection(dir);
+                    c.trackballManipulator().setViewDirection(dir);
                 }
             },
             v);
@@ -325,6 +353,7 @@ void InteractionTestLayer::resetCamera() {
     camera_->setPosition(kDefaultCameraPosition);
     camera_->setTarget(kDefaultTargetPosition);
     camera_->setUp(kDefaultCameraUp);
+    camera_->setSceneScale(1.0f);  // clear any accumulated SceneScale zoom
     camera_->updateMatrices();
     dispatchReset();
 }
@@ -362,7 +391,7 @@ void InteractionTestLayer::setRotationPivotMode(vne::interaction::OrbitPivotMode
         std::visit(
             [mode](auto& c) {
                 if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Inspect3DController>) {
-                    c.orbitalCameraManipulator().setPivotMode(mode);
+                    c.trackballManipulator().setPivotMode(mode);
                 }
             },
             v);
@@ -568,6 +597,7 @@ void InteractionSettingsLayer::renderPanel() {
     renderManipulatorSettings();
 
     const ControllerKind cur = il.getControllerKind();
+    const bool is_persp = !scene_layer_ || scene_layer_->uiSettings().use_perspective;
     const bool show_zoom =
         (cur == ControllerKind::eInspect3D || cur == ControllerKind::eNavigation || cur == ControllerKind::eOrtho2D);
     if (show_zoom) {
@@ -579,9 +609,43 @@ void InteractionSettingsLayer::renderPanel() {
                 il.setZoomMethod(zvals[ui.zoom_idx]);
             }
             ImGui::Spacing();
-            ImGui::TextDisabled("SceneScale: XY scene scale in view (virtual zoom)");
-            ImGui::TextDisabled("ChangeFov: widen/narrow FOV (perspective) or ortho extents");
-            ImGui::TextDisabled("DollyToCoi: move along view ray toward pivot");
+            if (ui.zoom_idx == 0) {
+                ImGui::TextDisabled("SceneScale: XY scale in view matrix — no clip change, works on both projections.");
+            } else if (ui.zoom_idx == 1) {
+                if (is_persp) {
+                    ImGui::TextDisabled("ChangeFov (persp): adjusts field-of-view angle.");
+                } else {
+                    ImGui::TextDisabled("ChangeFov (ortho): adjusts orthographic half-extents (same effect as dolly).");
+                }
+            } else {
+                if (is_persp) {
+                    ImGui::TextDisabled("DollyToCoi (persp): moves eye along view ray toward pivot.");
+                } else {
+                    ImGui::TextDisabled("DollyToCoi (ortho): adjusts ortho bounds anchored at cursor position.");
+                }
+            }
+        }
+    }
+
+    // On-switch policy
+    if (ImGui::CollapsingHeader("On Switch Policy")) {
+        ImGui::Checkbox("Reset scene scale on switch##policy", &ui.on_switch_reset_scene_scale);
+        ImGui::SameLine();
+        ImGui::TextDisabled("(?)");
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Clears accumulated SceneScale zoom when changing controller or projection.\nPrevents zoom artifacts carrying over.");
+        }
+        ImGui::Checkbox("Reset rig state on switch##policy", &ui.on_switch_reset_rig_state);
+        ImGui::SameLine();
+        ImGui::TextDisabled("(?)");
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Clears in-flight gestures (drag, inertia) when switching.\nPrevents orphaned pan/rotate velocity.");
+        }
+        ImGui::Checkbox("Reset pose to defaults on switch##policy", &ui.on_switch_reset_pose);
+        ImGui::SameLine();
+        ImGui::TextDisabled("(?)");
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Snaps camera back to default position/target when switching.\nUseful for clean comparisons between controllers.");
         }
     }
 
@@ -611,16 +675,78 @@ void InteractionSettingsLayer::renderPanel() {
     }
 
     if (ImGui::CollapsingHeader("Camera State", ImGuiTreeNodeFlags_DefaultOpen)) {
-        const auto pos = il.cameraPosition();
-        const auto tgt = il.cameraTarget();
-        ImGui::Text("Position: %.2f  %.2f  %.2f",
-                    static_cast<double>(pos.x()),
-                    static_cast<double>(pos.y()),
-                    static_cast<double>(pos.z()));
-        ImGui::Text("Target:   %.2f  %.2f  %.2f",
-                    static_cast<double>(tgt.x()),
-                    static_cast<double>(tgt.y()),
-                    static_cast<double>(tgt.z()));
+        const auto* cam_ptr = scene_layer_ ? scene_layer_->getActiveCameraPtr(0) : nullptr;
+        if (cam_ptr) {
+            const auto pos = cam_ptr->getPosition();
+            const auto tgt = cam_ptr->getTarget();
+            const auto quat = cam_ptr->getOrientation();
+            const float scene_scale = cam_ptr->getSceneScale();
+            const float look_dist = (pos - tgt).length();
+
+            ImGui::Text("Position:   %.3f  %.3f  %.3f", static_cast<double>(pos.x()), static_cast<double>(pos.y()), static_cast<double>(pos.z()));
+            ImGui::Text("Target:     %.3f  %.3f  %.3f  [derived, read-only]", static_cast<double>(tgt.x()), static_cast<double>(tgt.y()), static_cast<double>(tgt.z()));
+            ImGui::Text("Look dist:  %.3f", static_cast<double>(look_dist));
+            ImGui::Text("Quat(xyzw): %.3f  %.3f  %.3f  %.3f", static_cast<double>(quat.x), static_cast<double>(quat.y), static_cast<double>(quat.z), static_cast<double>(quat.w));
+            if (scene_scale != 1.0f) {
+                ImGui::TextColored(ImVec4(1.f, 0.45f, 0.15f, 1.f), "Scene scale: %.4f  (non-unity)", static_cast<double>(scene_scale));
+            } else {
+                ImGui::TextDisabled("Scene scale: 1.0 (identity)");
+            }
+            ImGui::Separator();
+
+            // Edit mode
+            const char* edit_modes[] = {"Look-at (pos + target + up)", "Pose (pos + euler)"};
+            ImGui::Combo("Edit mode##camedit", &ui.cam_edit_mode, edit_modes, 2);
+            ImGui::Spacing();
+
+            if (ui.cam_edit_mode == 0) {
+                ImGui::InputFloat3("Position##lookat", &ui.edit_pos.x());
+                ImGui::InputFloat3("Target##lookat", &ui.edit_target.x());
+                ImGui::InputFloat3("Up##lookat", &ui.edit_up.x());
+                if (ImGui::Button("Apply lookAt")) {
+                    cam_ptr->lookAt(ui.edit_pos, ui.edit_target, ui.edit_up);
+                    cam_ptr->updateMatrices();
+                    il.setCamerasFromScene();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("Snap from camera##lookat")) {
+                    ui.edit_pos = pos;
+                    ui.edit_target = tgt;
+                    ui.edit_up = cam_ptr->getUp();
+                }
+            } else {
+                ImGui::InputFloat3("Position##pose", &ui.edit_pos.x());
+                ImGui::SliderFloat("Yaw##pose", &ui.edit_yaw_deg, -180.f, 180.f, "%.1f deg");
+                ImGui::SliderFloat("Pitch##pose", &ui.edit_pitch_deg, -89.f, 89.f, "%.1f deg");
+                ImGui::SliderFloat("Roll##pose", &ui.edit_roll_deg, -180.f, 180.f, "%.1f deg");
+                if (ImGui::Button("Apply Pose")) {
+                    const float y = vne::math::degToRad(ui.edit_yaw_deg);
+                    const float p = vne::math::degToRad(ui.edit_pitch_deg);
+                    const float r = vne::math::degToRad(ui.edit_roll_deg);
+                    const vne::math::Quatf qy = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(0.f, 1.f, 0.f), y);
+                    const vne::math::Quatf qp = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(1.f, 0.f, 0.f), p);
+                    const vne::math::Quatf qr = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(0.f, 0.f, 1.f), r);
+                    const vne::math::Quatf final_q = (qy * qp * qr).normalized();
+                    cam_ptr->setOrientationView(ui.edit_pos, final_q);
+                    cam_ptr->updateMatrices();
+                    il.setCamerasFromScene();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("Snap from camera##pose")) {
+                    ui.edit_pos = pos;
+                    // Decompose quaternion into yaw/pitch/roll (ZYX Euler)
+                    const float sq = quat.w * quat.w;
+                    const float sx = quat.x * quat.x;
+                    const float sy = quat.y * quat.y;
+                    const float sz = quat.z * quat.z;
+                    ui.edit_pitch_deg = vne::math::radToDeg(std::asin(vne::math::clamp(2.0f * (quat.w * quat.x - quat.z * quat.y), -1.0f, 1.0f)));
+                    ui.edit_yaw_deg = vne::math::radToDeg(std::atan2(2.0f * (quat.w * quat.y + quat.x * quat.z), sq - sx - sy + sz));
+                    ui.edit_roll_deg = vne::math::radToDeg(std::atan2(2.0f * (quat.w * quat.z + quat.x * quat.y), sq + sx - sy - sz));
+                }
+            }
+        } else {
+            ImGui::TextDisabled("No camera attached.");
+        }
         ImGui::Spacing();
         if (ImGui::Button("Reset camera")) {
             il.resetCamera();
@@ -651,6 +777,11 @@ void InteractionSettingsLayer::renderCameraSettings() {
                 sl.syncCameraPositionTargetUp();
                 sl.setUsePerspective(use_persp);
                 if (!use_persp && !il.isManipulatorCompatibleWithCamera(false)) {
+                    SwitchPolicy pol;
+                    pol.reset_scene_scale = ui.on_switch_reset_scene_scale;
+                    pol.reset_rig_state = ui.on_switch_reset_rig_state;
+                    pol.reset_pose_to_default = ui.on_switch_reset_pose;
+                    il.setSwitchPolicy(pol);
                     il.setControllerKind(ControllerKind::eInspect3D);
                 }
                 il.setCamerasFromScene();
@@ -728,10 +859,31 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
         !last_manip_synced_controller_kind_.has_value() || *last_manip_synced_controller_kind_ != cur;
     if (window_appearing || controller_changed) {
         if (auto* insp = il.getInspectController()) {
+            auto& orb = insp->trackballManipulator();
             ui.rotation_enabled_insp = insp->isRotationEnabled();
+            ui.pan_enabled_insp = insp->isPanEnabled();
+            ui.zoom_enabled_insp = insp->isZoomEnabled();
+            ui.rotation_inertia_enabled_insp = orb.isRotationInertiaEnabled();
+            ui.pan_inertia_enabled_insp = orb.isPanInertiaEnabled();
+            ui.orbit_animation_enabled_insp = orb.isOrbitAnimationEnabled();
+            ui.fit_anim_duration_insp = orb.getFitAnimationDuration();
+            ui.trackball_rotation_scale_insp = orb.getTrackballRotationScale();
+            ui.pivot_on_dbl_click_insp = insp->isPivotOnDoubleClickEnabled();
             using TPM = vne::interaction::TrackballProjectionMode;
             ui.trackball_proj_insp_idx =
-                (insp->orbitalCameraManipulator().getTrackballProjectionMode() == TPM::eHyperbolic) ? 0 : 1;
+                (orb.getTrackballProjectionMode() == TPM::eHyperbolic) ? 0 : 1;
+        } else if (auto* nav = il.getNavController()) {
+            ui.nav_rotation_mode_idx = static_cast<int>(nav->getRotationMode());
+            ui.look_enabled_nav = nav->isLookEnabled();
+            ui.move_enabled_nav = nav->isMoveEnabled();
+            ui.zoom_enabled_nav = nav->isZoomEnabled();
+            ui.move_speed = nav->getMoveSpeed();
+            ui.mouse_sensitivity = nav->getMouseSensitivity();
+            ui.sprint_mult = nav->getSprintMultiplier();
+            ui.slow_mult = nav->getSlowMultiplier();
+        } else if (auto* ortho = il.getOrtho2DController()) {
+            ui.pan_inertia_enabled_ortho = ortho->ortho2DManipulator().isPanInertiaEnabled();
+            ui.rotate_sensitivity_ortho = ortho->ortho2DManipulator().getRotateSensitivityDegreesPerPixel();
         }
         last_manip_synced_controller_kind_ = cur;
     }
@@ -760,6 +912,12 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
             if (new_kind == ControllerKind::eOrtho2D && scene_layer_->uiSettings().use_perspective) {
                 ImGui::OpenPopup("Ortho2DNeedsOrthographicCamera");
             } else {
+                // Push current UI policy into the layer before switching.
+                SwitchPolicy pol;
+                pol.reset_scene_scale = ui.on_switch_reset_scene_scale;
+                pol.reset_rig_state = ui.on_switch_reset_rig_state;
+                pol.reset_pose_to_default = ui.on_switch_reset_pose;
+                il.setSwitchPolicy(pol);
                 il.setControllerKind(new_kind);
                 il.setCamerasFromScene();
             }
@@ -803,7 +961,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
 
         // Per-controller settings
         if (auto* insp = il.getInspectController()) {
-            auto& orb = insp->orbitalCameraManipulator();
+            auto& orb = insp->trackballManipulator();
             if (ImGui::TreeNodeEx("Inspect Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
                 using OPM = vne::interaction::OrbitPivotMode;
                 int pivot_idx = static_cast<int>(orb.getPivotMode());
@@ -830,9 +988,37 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 if (ImGui::Checkbox("Zoom enabled##insp", &ui.zoom_enabled_insp)) {
                     insp->setZoomEnabled(ui.zoom_enabled_insp);
                 }
+                // Inertia
+                ui.rotation_inertia_enabled_insp = orb.isRotationInertiaEnabled();
+                if (ImGui::Checkbox("Rotation inertia##insp", &ui.rotation_inertia_enabled_insp)) {
+                    orb.setRotationInertiaEnabled(ui.rotation_inertia_enabled_insp);
+                }
+                ui.pan_inertia_enabled_insp = orb.isPanInertiaEnabled();
+                if (ImGui::Checkbox("Pan inertia##insp", &ui.pan_inertia_enabled_insp)) {
+                    orb.setPanInertiaEnabled(ui.pan_inertia_enabled_insp);
+                }
+                // Animation
+                ui.orbit_animation_enabled_insp = orb.isOrbitAnimationEnabled();
+                if (ImGui::Checkbox("Fit/view animation##insp", &ui.orbit_animation_enabled_insp)) {
+                    insp->setOrbitAnimationEnabled(ui.orbit_animation_enabled_insp);
+                }
+                ui.fit_anim_duration_insp = orb.getFitAnimationDuration();
+                if (ImGui::SliderFloat("Fit anim duration##insp", &ui.fit_anim_duration_insp, 0.f, 1.5f, "%.2f s")) {
+                    orb.setFitAnimationDuration(ui.fit_anim_duration_insp);
+                }
+                // Pivot on double-click
+                ui.pivot_on_dbl_click_insp = insp->isPivotOnDoubleClickEnabled();
+                if (ImGui::Checkbox("Pivot on double-click##insp", &ui.pivot_on_dbl_click_insp)) {
+                    insp->setPivotOnDoubleClickEnabled(ui.pivot_on_dbl_click_insp);
+                }
+                // Speeds
                 float rs = orb.getRotationSpeed();
                 if (ImGui::SliderFloat("Rotation speed##insp", &rs, 0.1f, 5.f)) {
                     orb.setRotationSpeed(rs);
+                }
+                ui.trackball_rotation_scale_insp = orb.getTrackballRotationScale();
+                if (ImGui::SliderFloat("Trackball rot scale##insp", &ui.trackball_rotation_scale_insp, 0.5f, 8.f)) {
+                    orb.setTrackballRotationScale(ui.trackball_rotation_scale_insp);
                 }
                 float ps = orb.getPanSpeed();
                 if (ImGui::SliderFloat("Pan speed##insp", &ps, 0.1f, 10.f)) {
@@ -858,6 +1044,39 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
             }
         } else if (auto* nav = il.getNavController()) {
             if (ImGui::TreeNodeEx("Navigation Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
+                // Rotation mode
+                {
+                    using FLR = vne::interaction::FreeLookRotationMode;
+                    const char* rot_modes[] = {"YawPitch (default)", "Trackball (virtual ball)"};
+                    ui.nav_rotation_mode_idx = static_cast<int>(nav->getRotationMode());
+                    if (ImGui::Combo("Look mode##nav", &ui.nav_rotation_mode_idx, rot_modes, 2)) {
+                        nav->setRotationMode(ui.nav_rotation_mode_idx == 0 ? FLR::eYawPitch : FLR::eTrackball);
+                    }
+                }
+                // DOF enables
+                ui.look_enabled_nav = nav->isLookEnabled();
+                if (ImGui::Checkbox("Look enabled##nav", &ui.look_enabled_nav)) {
+                    nav->setLookEnabled(ui.look_enabled_nav);
+                }
+                ui.move_enabled_nav = nav->isMoveEnabled();
+                if (ImGui::Checkbox("Move enabled##nav", &ui.move_enabled_nav)) {
+                    nav->setMoveEnabled(ui.move_enabled_nav);
+                }
+                ui.zoom_enabled_nav = nav->isZoomEnabled();
+                if (ImGui::Checkbox("Zoom enabled##nav", &ui.zoom_enabled_nav)) {
+                    nav->setZoomEnabled(ui.zoom_enabled_nav);
+                }
+                // World up
+                {
+                    const char* up_names[] = {"Y-up (default)", "Z-up (CAD/scientific)"};
+                    if (ImGui::Combo("World up##nav", &ui.nav_world_up_idx, up_names, 2)) {
+                        const vne::math::Vec3f up_vec = (ui.nav_world_up_idx == 1)
+                            ? vne::math::Vec3f(0.f, 0.f, 1.f)
+                            : vne::math::Vec3f(0.f, 1.f, 0.f);
+                        nav->freeLookManipulator().setWorldUp(up_vec);
+                    }
+                }
+                // Speeds
                 ui.move_speed = nav->getMoveSpeed();
                 if (ImGui::SliderFloat("Move speed##nav", &ui.move_speed, 0.5f, 20.f)) {
                     nav->setMoveSpeed(ui.move_speed);
@@ -905,7 +1124,6 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                         ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "Right:   (not computed)");
                     } else {
                         const vne::math::Vec3f fwd = fwd_vec.normalized();
-                        // Build right from world-up candidates; never normalize a near-zero cross.
                         const vne::math::Vec3f up_candidates[3] = {
                             {0.f, 1.f, 0.f},
                             {1.f, 0.f, 0.f},
@@ -948,10 +1166,32 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
         } else if (auto* ortho = il.getOrtho2DController()) {
             auto& opz = ortho->ortho2DManipulator();
             if (ImGui::TreeNodeEx("Ortho 2D Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
+                // View direction presets
+                ImGui::TextDisabled("View direction:");
+                using VD = vne::interaction::ViewDirection;
+                struct { const char* label; VD dir; } vd_presets[] = {
+                    {"Front", VD::eFront}, {"Back", VD::eBack},
+                    {"Left", VD::eLeft}, {"Right", VD::eRight},
+                    {"Top", VD::eTop}, {"Bottom", VD::eBottom},
+                };
+                for (auto& vdp : vd_presets) {
+                    if (ImGui::Button(vdp.label)) {
+                        ortho->setViewDirection(vdp.dir);
+                    }
+                    ImGui::SameLine();
+                }
+                ImGui::NewLine();
+                // DOF
                 bool rot_en = ortho->isRotationEnabled();
                 if (ImGui::Checkbox("Rotation enabled##ortho", &rot_en)) {
                     ortho->setRotationEnabled(rot_en);
                 }
+                // Pan inertia
+                ui.pan_inertia_enabled_ortho = opz.isPanInertiaEnabled();
+                if (ImGui::Checkbox("Pan inertia##ortho", &ui.pan_inertia_enabled_ortho)) {
+                    ortho->setPanInertiaEnabled(ui.pan_inertia_enabled_ortho);
+                }
+                // Speeds
                 float zs = opz.getZoomSpeed();
                 if (ImGui::SliderFloat("Zoom speed##ortho", &zs, 1.01f, 1.5f, "%.3f")) {
                     opz.setZoomSpeed(zs);
@@ -960,6 +1200,13 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 if (ImGui::SliderFloat("Pan damping##ortho", &pd, 0.f, 20.f)) {
                     opz.setPanDamping(pd);
                 }
+                ui.rotate_sensitivity_ortho = opz.getRotateSensitivityDegreesPerPixel();
+                if (ImGui::SliderFloat("Rotate sensitivity##ortho", &ui.rotate_sensitivity_ortho, 0.05f, 3.f, "%.2f deg/px")) {
+                    ortho->setRotateSensitivity(ui.rotate_sensitivity_ortho);
+                }
+                // World units per pixel readout
+                ImGui::Spacing();
+                ImGui::Text("World units/pixel: %.4f", static_cast<double>(ortho->getWorldUnitsPerPixel()));
                 ImGui::TreePop();
             }
         }

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -15,7 +15,7 @@
 #include "demo_test_interaction.h"
 
 #include "vertexnova/interaction/free_look_manipulator.h"
-#include "vertexnova/interaction/orbital_camera_manipulator.h"
+#include "vertexnova/interaction/trackball_manipulator.h"
 #include "vertexnova/interaction/ortho_2d_manipulator.h"
 
 #include "vertexnova/testbed/app/application.h"
@@ -302,7 +302,7 @@ void InteractionTestLayer::setControllerKind(ControllerKind kind) {
     for (size_t i = 0; i < static_cast<size_t>(kMaxViewports); ++i) {
         controllers_[i] = makeController(kind, navigation_mode_);
         std::visit(
-            [this, vpw, vph](auto& c) {
+            [vpw, vph](auto& c) {
                 c.onResize(vpw, vph);
             },
             controllers_[i]);
@@ -675,7 +675,7 @@ void InteractionSettingsLayer::renderPanel() {
     }
 
     if (ImGui::CollapsingHeader("Camera State", ImGuiTreeNodeFlags_DefaultOpen)) {
-        const auto* cam_ptr = scene_layer_ ? scene_layer_->getActiveCameraPtr(0) : nullptr;
+        auto* cam_ptr = scene_layer_ ? scene_layer_->getActiveCameraPtr(0) : nullptr;
         if (cam_ptr) {
             const auto pos = cam_ptr->getPosition();
             const auto tgt = cam_ptr->getTarget();
@@ -862,8 +862,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
         if (auto* insp = il.getInspectController()) {
             auto& orb = insp->trackballManipulator();
             ui.rotation_enabled_insp = insp->isRotationEnabled();
-            ui.pan_enabled_insp = insp->isPanEnabled();
-            ui.zoom_enabled_insp = insp->isZoomEnabled();
+            // Pan/zoom toggles have no public getters on Inspect3DController; keep ui_ values from user edits.
             ui.rotation_inertia_enabled_insp = orb.isRotationInertiaEnabled();
             ui.pan_inertia_enabled_insp = orb.isPanInertiaEnabled();
             ui.orbit_animation_enabled_insp = orb.isOrbitAnimationEnabled();

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -984,6 +984,13 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
 
         // Per-controller settings
         if (auto* insp = il.getInspectController()) {
+            auto forEachInspect = [&](auto&& fn) {
+                for (int i = 0; i < InteractionTestLayer::kMaxViewports; ++i) {
+                    if (auto* ctrl = il.getInspectController(i)) {
+                        fn(*ctrl);
+                    }
+                }
+            };
             auto& orb = insp->trackballManipulator();
             if (ImGui::TreeNodeEx("Inspect Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
                 using OPM = vne::interaction::OrbitPivotMode;
@@ -992,80 +999,97 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                                              "View center (pan end updates COI)",
                                              "Fixed world (pan translates eye+target)"};
                 if (ImGui::Combo("Rotation pivot##insp", &pivot_idx, pivot_names, 3)) {
-                    orb.setPivotMode(static_cast<OPM>(pivot_idx));
+                    const auto mode = static_cast<OPM>(pivot_idx);
+                    forEachInspect([&](auto& c) { c.trackballManipulator().setPivotMode(mode); });
                 }
                 if (ImGui::Checkbox("Rotation enabled##insp", &ui.rotation_enabled_insp)) {
-                    insp->setRotationEnabled(ui.rotation_enabled_insp);
+                    forEachInspect([&](auto& c) { c.setRotationEnabled(ui.rotation_enabled_insp); });
                 }
                 {
                     using TPM = vne::interaction::TrackballProjectionMode;
                     const char* proj_names[] = {"Hyperbolic", "Rim"};
                     if (ImGui::Combo("Trackball projection##insp", &ui.trackball_proj_insp_idx, proj_names, 2)) {
-                        orb.setTrackballProjectionMode(ui.trackball_proj_insp_idx == 0 ? TPM::eHyperbolic : TPM::eRim);
+                        const auto proj =
+                            ui.trackball_proj_insp_idx == 0 ? TPM::eHyperbolic : TPM::eRim;
+                        forEachInspect(
+                            [&](auto& c) { c.trackballManipulator().setTrackballProjectionMode(proj); });
                     }
                     ImGui::TextDisabled("Hyperbolic: cap + continuation; Rim: hemisphere + equatorial rim");
                 }
                 if (ImGui::Checkbox("Pan enabled##insp", &ui.pan_enabled_insp)) {
-                    insp->setPanEnabled(ui.pan_enabled_insp);
+                    forEachInspect([&](auto& c) { c.setPanEnabled(ui.pan_enabled_insp); });
                 }
                 if (ImGui::Checkbox("Zoom enabled##insp", &ui.zoom_enabled_insp)) {
-                    insp->setZoomEnabled(ui.zoom_enabled_insp);
+                    forEachInspect([&](auto& c) { c.setZoomEnabled(ui.zoom_enabled_insp); });
                 }
                 // Inertia
                 ui.rotation_inertia_enabled_insp = orb.isRotationInertiaEnabled();
                 if (ImGui::Checkbox("Rotation inertia##insp", &ui.rotation_inertia_enabled_insp)) {
-                    orb.setRotationInertiaEnabled(ui.rotation_inertia_enabled_insp);
+                    forEachInspect([&](auto& c) {
+                        c.trackballManipulator().setRotationInertiaEnabled(ui.rotation_inertia_enabled_insp);
+                    });
                 }
                 ui.pan_inertia_enabled_insp = orb.isPanInertiaEnabled();
                 if (ImGui::Checkbox("Pan inertia##insp", &ui.pan_inertia_enabled_insp)) {
-                    orb.setPanInertiaEnabled(ui.pan_inertia_enabled_insp);
+                    forEachInspect(
+                        [&](auto& c) { c.trackballManipulator().setPanInertiaEnabled(ui.pan_inertia_enabled_insp); });
                 }
                 // Animation
                 ui.orbit_animation_enabled_insp = orb.isOrbitAnimationEnabled();
                 if (ImGui::Checkbox("Fit/view animation##insp", &ui.orbit_animation_enabled_insp)) {
-                    insp->setOrbitAnimationEnabled(ui.orbit_animation_enabled_insp);
+                    forEachInspect([&](auto& c) { c.setOrbitAnimationEnabled(ui.orbit_animation_enabled_insp); });
                 }
                 ui.fit_anim_duration_insp = orb.getFitAnimationDuration();
                 if (ImGui::SliderFloat("Fit anim duration##insp", &ui.fit_anim_duration_insp, 0.f, 1.5f, "%.2f s")) {
-                    orb.setFitAnimationDuration(ui.fit_anim_duration_insp);
+                    forEachInspect(
+                        [&](auto& c) { c.trackballManipulator().setFitAnimationDuration(ui.fit_anim_duration_insp); });
                 }
                 // Pivot on double-click
                 ui.pivot_on_dbl_click_insp = insp->isPivotOnDoubleClickEnabled();
                 if (ImGui::Checkbox("Pivot on double-click##insp", &ui.pivot_on_dbl_click_insp)) {
-                    insp->setPivotOnDoubleClickEnabled(ui.pivot_on_dbl_click_insp);
+                    forEachInspect([&](auto& c) { c.setPivotOnDoubleClickEnabled(ui.pivot_on_dbl_click_insp); });
                 }
                 // Speeds
                 float rs = orb.getRotationSpeed();
                 if (ImGui::SliderFloat("Rotation speed##insp", &rs, 0.1f, 5.f)) {
-                    orb.setRotationSpeed(rs);
+                    forEachInspect([&](auto& c) { c.trackballManipulator().setRotationSpeed(rs); });
                 }
                 ui.trackball_rotation_scale_insp = orb.getTrackballRotationScale();
                 if (ImGui::SliderFloat("Trackball rot scale##insp", &ui.trackball_rotation_scale_insp, 0.5f, 8.f)) {
-                    orb.setTrackballRotationScale(ui.trackball_rotation_scale_insp);
+                    forEachInspect([&](auto& c) {
+                        c.trackballManipulator().setTrackballRotationScale(ui.trackball_rotation_scale_insp);
+                    });
                 }
                 float ps = orb.getPanSpeed();
                 if (ImGui::SliderFloat("Pan speed##insp", &ps, 0.1f, 10.f)) {
-                    orb.setPanSpeed(ps);
+                    forEachInspect([&](auto& c) { c.trackballManipulator().setPanSpeed(ps); });
                 }
                 float zs = orb.getZoomSpeed();
                 if (ImGui::SliderFloat("Zoom speed##insp", &zs, 1.01f, 1.5f, "%.3f")) {
-                    orb.setZoomSpeed(zs);
+                    forEachInspect([&](auto& c) { c.trackballManipulator().setZoomSpeed(zs); });
                 }
                 float fs = orb.getFovZoomSpeed();
                 if (ImGui::SliderFloat("FOV zoom speed##insp", &fs, 1.01f, 1.2f, "%.3f")) {
-                    orb.setFovZoomSpeed(fs);
+                    forEachInspect([&](auto& c) { c.trackballManipulator().setFovZoomSpeed(fs); });
                 }
                 float rd = orb.getRotationDamping();
                 if (ImGui::SliderFloat("Rotation damping##insp", &rd, 0.f, 20.f)) {
-                    orb.setRotationDamping(rd);
+                    forEachInspect([&](auto& c) { c.trackballManipulator().setRotationDamping(rd); });
                 }
                 float pd = orb.getPanDamping();
                 if (ImGui::SliderFloat("Pan damping##insp", &pd, 0.f, 20.f)) {
-                    orb.setPanDamping(pd);
+                    forEachInspect([&](auto& c) { c.trackballManipulator().setPanDamping(pd); });
                 }
                 ImGui::TreePop();
             }
         } else if (auto* nav = il.getNavController()) {
+            auto forEachNav = [&](auto&& fn) {
+                for (int i = 0; i < InteractionTestLayer::kMaxViewports; ++i) {
+                    if (auto* ctrl = il.getNavController(i)) {
+                        fn(*ctrl);
+                    }
+                }
+            };
             if (ImGui::TreeNodeEx("Navigation Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
                 // Rotation mode
                 {
@@ -1073,21 +1097,22 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                     const char* rot_modes[] = {"YawPitch (default)", "Trackball (virtual ball)"};
                     ui.nav_rotation_mode_idx = static_cast<int>(nav->getRotationMode());
                     if (ImGui::Combo("Look mode##nav", &ui.nav_rotation_mode_idx, rot_modes, 2)) {
-                        nav->setRotationMode(ui.nav_rotation_mode_idx == 0 ? FLR::eYawPitch : FLR::eTrackball);
+                        const auto mode = ui.nav_rotation_mode_idx == 0 ? FLR::eYawPitch : FLR::eTrackball;
+                        forEachNav([&](auto& c) { c.setRotationMode(mode); });
                     }
                 }
                 // DOF enables
                 ui.look_enabled_nav = nav->isLookEnabled();
                 if (ImGui::Checkbox("Look enabled##nav", &ui.look_enabled_nav)) {
-                    nav->setLookEnabled(ui.look_enabled_nav);
+                    forEachNav([&](auto& c) { c.setLookEnabled(ui.look_enabled_nav); });
                 }
                 ui.move_enabled_nav = nav->isMoveEnabled();
                 if (ImGui::Checkbox("Move enabled##nav", &ui.move_enabled_nav)) {
-                    nav->setMoveEnabled(ui.move_enabled_nav);
+                    forEachNav([&](auto& c) { c.setMoveEnabled(ui.move_enabled_nav); });
                 }
                 ui.zoom_enabled_nav = nav->isZoomEnabled();
                 if (ImGui::Checkbox("Zoom enabled##nav", &ui.zoom_enabled_nav)) {
-                    nav->setZoomEnabled(ui.zoom_enabled_nav);
+                    forEachNav([&](auto& c) { c.setZoomEnabled(ui.zoom_enabled_nav); });
                 }
                 // World up
                 {
@@ -1095,30 +1120,30 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                     if (ImGui::Combo("World up##nav", &ui.nav_world_up_idx, up_names, 2)) {
                         const vne::math::Vec3f up_vec = (ui.nav_world_up_idx == 1) ? vne::math::Vec3f(0.f, 0.f, 1.f)
                                                                                    : vne::math::Vec3f(0.f, 1.f, 0.f);
-                        nav->freeLookManipulator().setWorldUp(up_vec);
+                        forEachNav([&](auto& c) { c.freeLookManipulator().setWorldUp(up_vec); });
                     }
                 }
                 // Speeds
                 ui.move_speed = nav->getMoveSpeed();
                 if (ImGui::SliderFloat("Move speed##nav", &ui.move_speed, 0.5f, 20.f)) {
-                    nav->setMoveSpeed(ui.move_speed);
+                    forEachNav([&](auto& c) { c.setMoveSpeed(ui.move_speed); });
                 }
                 ui.mouse_sensitivity = nav->getMouseSensitivity();
                 if (ImGui::SliderFloat("Mouse sensitivity##nav", &ui.mouse_sensitivity, 0.05f, 0.5f)) {
-                    nav->setMouseSensitivity(ui.mouse_sensitivity);
+                    forEachNav([&](auto& c) { c.setMouseSensitivity(ui.mouse_sensitivity); });
                 }
                 ui.sprint_mult = nav->getSprintMultiplier();
                 if (ImGui::SliderFloat("Sprint multiplier##nav", &ui.sprint_mult, 1.f, 5.f)) {
-                    nav->setSprintMultiplier(ui.sprint_mult);
+                    forEachNav([&](auto& c) { c.setSprintMultiplier(ui.sprint_mult); });
                 }
                 ui.slow_mult = nav->getSlowMultiplier();
                 if (ImGui::SliderFloat("Slow multiplier##nav", &ui.slow_mult, 0.1f, 1.f)) {
-                    nav->setSlowMultiplier(ui.slow_mult);
+                    forEachNav([&](auto& c) { c.setSlowMultiplier(ui.slow_mult); });
                 }
                 if (ImGui::TreeNodeEx("Scroll zoom", ImGuiTreeNodeFlags_DefaultOpen)) {
                     float fl_z = nav->freeLookManipulator().getZoomSpeed();
                     if (ImGui::SliderFloat("Wheel zoom exponent##nav", &fl_z, 1.01f, 1.5f, "%.3f")) {
-                        nav->freeLookManipulator().setZoomSpeed(fl_z);
+                        forEachNav([&](auto& c) { c.freeLookManipulator().setZoomSpeed(fl_z); });
                     }
                     ImGui::TextDisabled("Scroll wheel zoom is handled by FreeLookManipulator.");
                     ImGui::TreePop();

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -819,9 +819,10 @@ void InteractionSettingsLayer::renderCameraSettings() {
             il.setCamerasFromScene();
         }
 
-        ImGui::Checkbox("Show view matrix", &ui.show_view_matrix);
-        ImGui::Checkbox("Show projection matrix", &ui.show_projection_matrix);
-        if (ui.show_view_matrix && sl.getActiveCameraPtr(0)) {
+        auto& sl_ui = sl.uiSettings();
+        ImGui::Checkbox("Show view matrix", &sl_ui.show_view_matrix);
+        ImGui::Checkbox("Show projection matrix", &sl_ui.show_projection_matrix);
+        if (sl_ui.show_view_matrix && sl.getActiveCameraPtr(0)) {
             const vne::math::Mat4f view = sl.getActiveCameraPtr(0)->getViewMatrix();
             ImGui::Text("View matrix (column-major):");
             for (size_t row = 0; row < 4u; ++row) {
@@ -832,7 +833,7 @@ void InteractionSettingsLayer::renderCameraSettings() {
                             static_cast<double>(view[3][row]));
             }
         }
-        if (ui.show_projection_matrix && sl.getActiveCameraPtr(0)) {
+        if (sl_ui.show_projection_matrix && sl.getActiveCameraPtr(0)) {
             const vne::math::Mat4f proj = sl.getActiveCameraPtr(0)->getProjectionMatrix();
             ImGui::Text("Projection matrix (column-major):");
             for (size_t row = 0; row < 4u; ++row) {
@@ -883,7 +884,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
             ui.slow_mult = nav->getSlowMultiplier();
         } else if (auto* ortho = il.getOrtho2DController()) {
             ui.pan_inertia_enabled_ortho = ortho->ortho2DManipulator().isPanInertiaEnabled();
-            ui.rotate_sensitivity_ortho = ortho->ortho2DManipulator().getRotateSensitivityDegreesPerPixel();
+            ui.rotate_sensitivity_ortho = ortho->ortho2DManipulator().getRotationSensitivityDegreesPerPixel();
         }
         last_manip_synced_controller_kind_ = cur;
     }
@@ -1200,7 +1201,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 if (ImGui::SliderFloat("Pan damping##ortho", &pd, 0.f, 20.f)) {
                     opz.setPanDamping(pd);
                 }
-                ui.rotate_sensitivity_ortho = opz.getRotateSensitivityDegreesPerPixel();
+                ui.rotate_sensitivity_ortho = opz.getRotationSensitivityDegreesPerPixel();
                 if (ImGui::SliderFloat("Rotate sensitivity##ortho", &ui.rotate_sensitivity_ortho, 0.05f, 3.f, "%.2f deg/px")) {
                     ortho->setRotateSensitivity(ui.rotate_sensitivity_ortho);
                 }

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -715,9 +715,17 @@ void InteractionSettingsLayer::renderPanel() {
                 ImGui::InputFloat3("Target##lookat", &ui.edit_target.x());
                 ImGui::InputFloat3("Up##lookat", &ui.edit_up.x());
                 if (ImGui::Button("Apply lookAt")) {
-                    cam_ptr->lookAt(ui.edit_pos, ui.edit_target, ui.edit_up);
-                    cam_ptr->updateMatrices();
-                    il.setCamerasFromScene();
+                    if (scene_layer_) {
+                        for (const auto& cam : scene_layer_->getActiveCameras()) {
+                            if (cam) {
+                                cam->lookAt(ui.edit_pos, ui.edit_target, ui.edit_up);
+                                cam->updateMatrices();
+                            }
+                        }
+                        scene_layer_->syncCameraPositionTargetUp();
+                        scene_layer_->invalidateOrthoProjectionSync();
+                        il.setCamerasFromScene();
+                    }
                 }
                 ImGui::SameLine();
                 if (ImGui::Button("Snap from camera##lookat")) {
@@ -731,16 +739,24 @@ void InteractionSettingsLayer::renderPanel() {
                 ImGui::SliderFloat("Pitch##pose", &ui.edit_pitch_deg, -89.f, 89.f, "%.1f deg");
                 ImGui::SliderFloat("Roll##pose", &ui.edit_roll_deg, -180.f, 180.f, "%.1f deg");
                 if (ImGui::Button("Apply Pose")) {
-                    const float y = vne::math::degToRad(ui.edit_yaw_deg);
-                    const float p = vne::math::degToRad(ui.edit_pitch_deg);
-                    const float r = vne::math::degToRad(ui.edit_roll_deg);
-                    const vne::math::Quatf qy = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(0.f, 1.f, 0.f), y);
-                    const vne::math::Quatf qp = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(1.f, 0.f, 0.f), p);
-                    const vne::math::Quatf qr = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(0.f, 0.f, 1.f), r);
-                    const vne::math::Quatf final_q = (qy * qp * qr).normalized();
-                    cam_ptr->setOrientationView(ui.edit_pos, final_q);
-                    cam_ptr->updateMatrices();
-                    il.setCamerasFromScene();
+                    if (scene_layer_) {
+                        const float y = vne::math::degToRad(ui.edit_yaw_deg);
+                        const float p = vne::math::degToRad(ui.edit_pitch_deg);
+                        const float r = vne::math::degToRad(ui.edit_roll_deg);
+                        const vne::math::Quatf qy = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(0.f, 1.f, 0.f), y);
+                        const vne::math::Quatf qp = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(1.f, 0.f, 0.f), p);
+                        const vne::math::Quatf qr = vne::math::Quatf::fromAxisAngle(vne::math::Vec3f(0.f, 0.f, 1.f), r);
+                        const vne::math::Quatf final_q = (qy * qp * qr).normalized();
+                        for (const auto& cam : scene_layer_->getActiveCameras()) {
+                            if (cam) {
+                                cam->setOrientationView(ui.edit_pos, final_q);
+                                cam->updateMatrices();
+                            }
+                        }
+                        scene_layer_->syncCameraPositionTargetUp();
+                        scene_layer_->invalidateOrthoProjectionSync();
+                        il.setCamerasFromScene();
+                    }
                 }
                 ImGui::SameLine();
                 if (ImGui::Button("Snap from camera##pose")) {

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -150,11 +150,11 @@ void InteractionTestLayer::dispatchEvent(const vne::events::Event& event, int vi
 
     // Use the real frame dt for mouse-move/drag events so pan inertia velocity is sampled correctly.
     // Key-repeat events still use kFixedDt (key hold timing is frame-rate independent).
-    const bool is_mouse_event = (event.type() == vne::events::EventType::eMouseMoved
-                                 || event.type() == vne::events::EventType::eMouseScrolled
-                                 || event.type() == vne::events::EventType::eMouseButtonPressed
-                                 || event.type() == vne::events::EventType::eMouseButtonReleased
-                                 || event.type() == vne::events::EventType::eMouseButtonDoubleClicked);
+    const bool is_mouse_event =
+        (event.type() == vne::events::EventType::eMouseMoved || event.type() == vne::events::EventType::eMouseScrolled
+         || event.type() == vne::events::EventType::eMouseButtonPressed
+         || event.type() == vne::events::EventType::eMouseButtonReleased
+         || event.type() == vne::events::EventType::eMouseButtonDoubleClicked);
     const double event_dt = is_mouse_event ? last_frame_dt_ : kFixedDt;
 
     std::visit(
@@ -301,11 +301,7 @@ void InteractionTestLayer::setControllerKind(ControllerKind kind) {
     const auto vph = kDefaultViewportH;
     for (size_t i = 0; i < static_cast<size_t>(kMaxViewports); ++i) {
         controllers_[i] = makeController(kind, navigation_mode_);
-        std::visit(
-            [vpw, vph](auto& c) {
-                c.onResize(vpw, vph);
-            },
-            controllers_[i]);
+        std::visit([vpw, vph](auto& c) { c.onResize(vpw, vph); }, controllers_[i]);
     }
 
     // Step 2: reset rig + mapper state on fresh controllers before attaching camera.
@@ -633,19 +629,22 @@ void InteractionSettingsLayer::renderPanel() {
         ImGui::SameLine();
         ImGui::TextDisabled("(?)");
         if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Clears accumulated SceneScale zoom when changing controller or projection.\nPrevents zoom artifacts carrying over.");
+            ImGui::SetTooltip("Clears accumulated SceneScale zoom when changing controller or projection.\nPrevents "
+                              "zoom artifacts carrying over.");
         }
         ImGui::Checkbox("Reset rig state on switch##policy", &ui.on_switch_reset_rig_state);
         ImGui::SameLine();
         ImGui::TextDisabled("(?)");
         if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Clears in-flight gestures (drag, inertia) when switching.\nPrevents orphaned pan/rotate velocity.");
+            ImGui::SetTooltip(
+                "Clears in-flight gestures (drag, inertia) when switching.\nPrevents orphaned pan/rotate velocity.");
         }
         ImGui::Checkbox("Reset pose to defaults on switch##policy", &ui.on_switch_reset_pose);
         ImGui::SameLine();
         ImGui::TextDisabled("(?)");
         if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Snaps camera back to default position/target when switching.\nUseful for clean comparisons between controllers.");
+            ImGui::SetTooltip("Snaps camera back to default position/target when switching.\nUseful for clean "
+                              "comparisons between controllers.");
         }
     }
 
@@ -683,12 +682,24 @@ void InteractionSettingsLayer::renderPanel() {
             const float scene_scale = cam_ptr->getSceneScale();
             const float look_dist = (pos - tgt).length();
 
-            ImGui::Text("Position:   %.3f  %.3f  %.3f", static_cast<double>(pos.x()), static_cast<double>(pos.y()), static_cast<double>(pos.z()));
-            ImGui::Text("Target:     %.3f  %.3f  %.3f  [derived, read-only]", static_cast<double>(tgt.x()), static_cast<double>(tgt.y()), static_cast<double>(tgt.z()));
+            ImGui::Text("Position:   %.3f  %.3f  %.3f",
+                        static_cast<double>(pos.x()),
+                        static_cast<double>(pos.y()),
+                        static_cast<double>(pos.z()));
+            ImGui::Text("Target:     %.3f  %.3f  %.3f  [derived, read-only]",
+                        static_cast<double>(tgt.x()),
+                        static_cast<double>(tgt.y()),
+                        static_cast<double>(tgt.z()));
             ImGui::Text("Look dist:  %.3f", static_cast<double>(look_dist));
-            ImGui::Text("Quat(xyzw): %.3f  %.3f  %.3f  %.3f", static_cast<double>(quat.x), static_cast<double>(quat.y), static_cast<double>(quat.z), static_cast<double>(quat.w));
+            ImGui::Text("Quat(xyzw): %.3f  %.3f  %.3f  %.3f",
+                        static_cast<double>(quat.x),
+                        static_cast<double>(quat.y),
+                        static_cast<double>(quat.z),
+                        static_cast<double>(quat.w));
             if (scene_scale != 1.0f) {
-                ImGui::TextColored(ImVec4(1.f, 0.45f, 0.15f, 1.f), "Scene scale: %.4f  (non-unity)", static_cast<double>(scene_scale));
+                ImGui::TextColored(ImVec4(1.f, 0.45f, 0.15f, 1.f),
+                                   "Scene scale: %.4f  (non-unity)",
+                                   static_cast<double>(scene_scale));
             } else {
                 ImGui::TextDisabled("Scene scale: 1.0 (identity)");
             }
@@ -739,9 +750,12 @@ void InteractionSettingsLayer::renderPanel() {
                     const float sx = quat.x * quat.x;
                     const float sy = quat.y * quat.y;
                     const float sz = quat.z * quat.z;
-                    ui.edit_pitch_deg = vne::math::radToDeg(std::asin(vne::math::clamp(2.0f * (quat.w * quat.x - quat.z * quat.y), -1.0f, 1.0f)));
-                    ui.edit_yaw_deg = vne::math::radToDeg(std::atan2(2.0f * (quat.w * quat.y + quat.x * quat.z), sq - sx - sy + sz));
-                    ui.edit_roll_deg = vne::math::radToDeg(std::atan2(2.0f * (quat.w * quat.z + quat.x * quat.y), sq + sx - sy - sz));
+                    ui.edit_pitch_deg = vne::math::radToDeg(
+                        std::asin(vne::math::clamp(2.0f * (quat.w * quat.x - quat.z * quat.y), -1.0f, 1.0f)));
+                    ui.edit_yaw_deg =
+                        vne::math::radToDeg(std::atan2(2.0f * (quat.w * quat.y + quat.x * quat.z), sq - sx - sy + sz));
+                    ui.edit_roll_deg =
+                        vne::math::radToDeg(std::atan2(2.0f * (quat.w * quat.z + quat.x * quat.y), sq + sx - sy - sz));
                 }
             }
         } else {
@@ -870,8 +884,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
             ui.trackball_rotation_scale_insp = orb.getTrackballRotationScale();
             ui.pivot_on_dbl_click_insp = insp->isPivotOnDoubleClickEnabled();
             using TPM = vne::interaction::TrackballProjectionMode;
-            ui.trackball_proj_insp_idx =
-                (orb.getTrackballProjectionMode() == TPM::eHyperbolic) ? 0 : 1;
+            ui.trackball_proj_insp_idx = (orb.getTrackballProjectionMode() == TPM::eHyperbolic) ? 0 : 1;
         } else if (auto* nav = il.getNavController()) {
             ui.nav_rotation_mode_idx = static_cast<int>(nav->getRotationMode());
             ui.look_enabled_nav = nav->isLookEnabled();
@@ -1070,9 +1083,8 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 {
                     const char* up_names[] = {"Y-up (default)", "Z-up (CAD/scientific)"};
                     if (ImGui::Combo("World up##nav", &ui.nav_world_up_idx, up_names, 2)) {
-                        const vne::math::Vec3f up_vec = (ui.nav_world_up_idx == 1)
-                            ? vne::math::Vec3f(0.f, 0.f, 1.f)
-                            : vne::math::Vec3f(0.f, 1.f, 0.f);
+                        const vne::math::Vec3f up_vec = (ui.nav_world_up_idx == 1) ? vne::math::Vec3f(0.f, 0.f, 1.f)
+                                                                                   : vne::math::Vec3f(0.f, 1.f, 0.f);
                         nav->freeLookManipulator().setWorldUp(up_vec);
                     }
                 }
@@ -1169,10 +1181,16 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 // View direction presets
                 ImGui::TextDisabled("View direction:");
                 using VD = vne::interaction::ViewDirection;
-                struct { const char* label; VD dir; } vd_presets[] = {
-                    {"Front", VD::eFront}, {"Back", VD::eBack},
-                    {"Left", VD::eLeft}, {"Right", VD::eRight},
-                    {"Top", VD::eTop}, {"Bottom", VD::eBottom},
+                struct {
+                    const char* label;
+                    VD dir;
+                } vd_presets[] = {
+                    {"Front", VD::eFront},
+                    {"Back", VD::eBack},
+                    {"Left", VD::eLeft},
+                    {"Right", VD::eRight},
+                    {"Top", VD::eTop},
+                    {"Bottom", VD::eBottom},
                 };
                 for (auto& vdp : vd_presets) {
                     if (ImGui::Button(vdp.label)) {
@@ -1201,7 +1219,11 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                     opz.setPanDamping(pd);
                 }
                 ui.rotate_sensitivity_ortho = opz.getRotationSensitivityDegreesPerPixel();
-                if (ImGui::SliderFloat("Rotate sensitivity##ortho", &ui.rotate_sensitivity_ortho, 0.05f, 3.f, "%.2f deg/px")) {
+                if (ImGui::SliderFloat("Rotate sensitivity##ortho",
+                                       &ui.rotate_sensitivity_ortho,
+                                       0.05f,
+                                       3.f,
+                                       "%.2f deg/px")) {
                     ortho->setRotateSensitivity(ui.rotate_sensitivity_ortho);
                 }
                 // World units per pixel readout

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -44,6 +44,7 @@
 #include "../common/path_utils.h"
 
 #include <filesystem>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -806,14 +807,6 @@ void InteractionSettingsLayer::renderCameraSettings() {
             } else {
                 sl.syncCameraPositionTargetUp();
                 sl.setUsePerspective(use_persp);
-                if (!use_persp && !il.isManipulatorCompatibleWithCamera(false)) {
-                    SwitchPolicy pol;
-                    pol.reset_scene_scale = ui.on_switch_reset_scene_scale;
-                    pol.reset_rig_state = ui.on_switch_reset_rig_state;
-                    pol.reset_pose_to_default = ui.on_switch_reset_pose;
-                    il.setSwitchPolicy(pol);
-                    il.setControllerKind(ControllerKind::eInspect3D);
-                }
                 il.setCamerasFromScene();
             }
         }
@@ -924,8 +917,9 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
             ControllerKind::eNavigation,
             ControllerKind::eOrtho2D,
         };
+        const auto count = std::size(types);
         int idx = 0;
-        for (int i = 0; i < 3; ++i) {
+        for (int i = 0; i < static_cast<int>(count); ++i) {
             if (values[i] == cur) {
                 idx = i;
                 break;
@@ -936,7 +930,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
         if (need_ortho) {
             ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "Ortho 2D requires Orthographic camera");
         }
-        if (ImGui::Combo("Type##ctrl", &idx, types, 3)) {
+        if (ImGui::Combo("Type##ctrl", &idx, types, static_cast<int>(count))) {
             const ControllerKind new_kind = values[idx];
             if (new_kind == ControllerKind::eOrtho2D && scene_layer_->uiSettings().use_perspective) {
                 ImGui::OpenPopup("Ortho2DNeedsOrthographicCamera");

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -14,7 +14,6 @@
 
 #include "demo_test_interaction.h"
 
-#include "vertexnova/interaction/follow_manipulator.h"
 #include "vertexnova/interaction/free_look_manipulator.h"
 #include "vertexnova/interaction/orbital_camera_manipulator.h"
 #include "vertexnova/interaction/ortho_2d_manipulator.h"
@@ -66,27 +65,15 @@ const vne::math::Vec3f kDefaultCameraUp{0.0f, 1.0f, 0.0f};
 
 ControllerVariant makeController(ControllerKind kind, vne::interaction::FreeLookMode nav_mode) {
     switch (kind) {
-        case ControllerKind::eInspectOrbit: {
-            vne::interaction::Inspect3DController c;
-            c.setRotationMode(vne::interaction::OrbitalRotationMode::eOrbit);
-            return c;
-        }
-        case ControllerKind::eInspectTrackball: {
-            vne::interaction::Inspect3DController c;
-            c.setRotationMode(vne::interaction::OrbitalRotationMode::eTrackball);
-            return c;
-        }
+        case ControllerKind::eInspect3D:
+            return vne::interaction::Inspect3DController{};
         case ControllerKind::eNavigation: {
             vne::interaction::Navigation3DController c;
             c.setMode(nav_mode);
             return c;
         }
-        case ControllerKind::eOrtho2D: {
+        case ControllerKind::eOrtho2D:
             return vne::interaction::Ortho2DController{};
-        }
-        case ControllerKind::eFollow: {
-            return vne::interaction::FollowController{};
-        }
     }
     return vne::interaction::Inspect3DController{};
 }
@@ -100,7 +87,7 @@ ControllerVariant makeController(ControllerKind kind, vne::interaction::FreeLook
 InteractionTestLayer::InteractionTestLayer()
     : vne::testbed::ILayer("InteractionTestLayer") {
     for (size_t i = 0; i < static_cast<size_t>(kMaxViewports); ++i) {
-        controllers_[i] = makeController(ControllerKind::eInspectTrackball, navigation_mode_);
+        controllers_[i] = makeController(ControllerKind::eInspect3D, navigation_mode_);
     }
 }
 
@@ -172,15 +159,13 @@ void InteractionTestLayer::dispatchEvent(const vne::events::Event& event, int vi
             if (needs_cursor_position) {
                 const auto [mx, my] = vne::events::Input::mousePosition();
                 const vne::events::MouseMovedEvent mm(mx, my);
-                if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Ortho2DController>
-                              || std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::FollowController>) {
+                if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Ortho2DController>) {
                     c.onEvent(mm);
                 } else {
                     c.onEvent(mm, 0.0);
                 }
             }
-            if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Ortho2DController>
-                          || std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::FollowController>) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Ortho2DController>) {
                 c.onEvent(event);
             } else {
                 c.onEvent(event, kFixedDt);
@@ -315,8 +300,6 @@ void InteractionTestLayer::setZoomMethod(vne::interaction::ZoomMethod method) {
                     c.freeLookManipulator().setZoomMethod(method);
                 } else if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::Ortho2DController>) {
                     c.ortho2DManipulator().setZoomMethod(method);
-                } else if constexpr (std::is_same_v<std::decay_t<decltype(c)>, vne::interaction::FollowController>) {
-                    c.followManipulator().setZoomMethod(method);
                 }
             },
             v);
@@ -437,8 +420,7 @@ vne::math::Vec3f InteractionTestLayer::cameraTarget() const {
 }
 
 vne::interaction::Inspect3DController* InteractionTestLayer::getInspectController(int index) noexcept {
-    if (index < 0 || index >= kMaxViewports
-        || (current_kind_ != ControllerKind::eInspectOrbit && current_kind_ != ControllerKind::eInspectTrackball)) {
+    if (index < 0 || index >= kMaxViewports || current_kind_ != ControllerKind::eInspect3D) {
         return nullptr;
     }
     return std::get_if<vne::interaction::Inspect3DController>(&controllers_[static_cast<size_t>(index)]);
@@ -456,13 +438,6 @@ vne::interaction::Ortho2DController* InteractionTestLayer::getOrtho2DController(
         return nullptr;
     }
     return std::get_if<vne::interaction::Ortho2DController>(&controllers_[static_cast<size_t>(index)]);
-}
-
-vne::interaction::FollowController* InteractionTestLayer::getFollowController(int index) noexcept {
-    if (index < 0 || index >= kMaxViewports || current_kind_ != ControllerKind::eFollow) {
-        return nullptr;
-    }
-    return std::get_if<vne::interaction::FollowController>(&controllers_[static_cast<size_t>(index)]);
 }
 
 // ---------------------------------------------------------------------------
@@ -594,8 +569,7 @@ void InteractionSettingsLayer::renderPanel() {
 
     const ControllerKind cur = il.getControllerKind();
     const bool show_zoom =
-        (cur == ControllerKind::eInspectOrbit || cur == ControllerKind::eInspectTrackball
-         || cur == ControllerKind::eNavigation || cur == ControllerKind::eOrtho2D || cur == ControllerKind::eFollow);
+        (cur == ControllerKind::eInspect3D || cur == ControllerKind::eNavigation || cur == ControllerKind::eOrtho2D);
     if (show_zoom) {
         if (ImGui::CollapsingHeader("Zoom Method", ImGuiTreeNodeFlags_DefaultOpen)) {
             using ZM = vne::interaction::ZoomMethod;
@@ -611,7 +585,7 @@ void InteractionSettingsLayer::renderPanel() {
         }
     }
 
-    if (cur == ControllerKind::eInspectOrbit || cur == ControllerKind::eInspectTrackball) {
+    if (cur == ControllerKind::eInspect3D) {
         if (ImGui::CollapsingHeader("View Direction", ImGuiTreeNodeFlags_DefaultOpen)) {
             using VD = vne::interaction::ViewDirection;
             struct {
@@ -677,7 +651,7 @@ void InteractionSettingsLayer::renderCameraSettings() {
                 sl.syncCameraPositionTargetUp();
                 sl.setUsePerspective(use_persp);
                 if (!use_persp && !il.isManipulatorCompatibleWithCamera(false)) {
-                    il.setControllerKind(ControllerKind::eInspectTrackball);
+                    il.setControllerKind(ControllerKind::eInspect3D);
                 }
                 il.setCamerasFromScene();
             }
@@ -755,34 +729,33 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
     if (window_appearing || controller_changed) {
         if (auto* insp = il.getInspectController()) {
             ui.rotation_enabled_insp = insp->isRotationEnabled();
-            ui.rotation_mode_insp_idx =
-                (insp->getRotationMode() == vne::interaction::OrbitalRotationMode::eOrbit) ? 0 : 1;
+            using TPM = vne::interaction::TrackballProjectionMode;
+            ui.trackball_proj_insp_idx =
+                (insp->orbitalCameraManipulator().getTrackballProjectionMode() == TPM::eHyperbolic) ? 0 : 1;
         }
         last_manip_synced_controller_kind_ = cur;
     }
 
     if (ImGui::CollapsingHeader("Controller", ImGuiTreeNodeFlags_DefaultOpen)) {
-        const char* types[] = {"Inspect 3D", "Navigation 3D", "Ortho 2D", "Follow"};
-        const ControllerKind values[] = {ControllerKind::eInspectOrbit,
-                                         ControllerKind::eNavigation,
-                                         ControllerKind::eOrtho2D,
-                                         ControllerKind::eFollow};
+        const char* types[] = {"Inspect 3D", "Navigation 3D", "Ortho 2D"};
+        const ControllerKind values[] = {
+            ControllerKind::eInspect3D,
+            ControllerKind::eNavigation,
+            ControllerKind::eOrtho2D,
+        };
         int idx = 0;
-        for (int i = 0; i < 4; ++i) {
+        for (int i = 0; i < 3; ++i) {
             if (values[i] == cur) {
                 idx = i;
                 break;
             }
-        }
-        if (cur == ControllerKind::eInspectTrackball) {
-            idx = 0;  // Legacy state maps to Inspect 3D entry.
         }
         const bool ortho_only = (cur == ControllerKind::eOrtho2D);
         const bool need_ortho = ortho_only && scene_layer_->uiSettings().use_perspective;
         if (need_ortho) {
             ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "Ortho 2D requires Orthographic camera");
         }
-        if (ImGui::Combo("Type##ctrl", &idx, types, 4)) {
+        if (ImGui::Combo("Type##ctrl", &idx, types, 3)) {
             const ControllerKind new_kind = values[idx];
             if (new_kind == ControllerKind::eOrtho2D && scene_layer_->uiSettings().use_perspective) {
                 ImGui::OpenPopup("Ortho2DNeedsOrthographicCamera");
@@ -817,20 +790,14 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
 
         ImGui::Spacing();
         switch (cur) {
-            case ControllerKind::eInspectOrbit:
-                ImGui::TextDisabled("LMB rotate  RMB pan  Scroll zoom");
-                break;
-            case ControllerKind::eInspectTrackball:
-                ImGui::TextDisabled("Inspect 3D: Orbit / Trackball selectable below");
+            case ControllerKind::eInspect3D:
+                ImGui::TextDisabled("LMB rotate (trackball)  RMB pan  Scroll zoom");
                 break;
             case ControllerKind::eNavigation:
                 ImGui::TextDisabled("RMB look, WASD/QE move, scroll zoom (FPS / Fly via Navigation mode)");
                 break;
             case ControllerKind::eOrtho2D:
                 ImGui::TextDisabled("LMB/RMB pan  Scroll zoom (no rotate)");
-                break;
-            case ControllerKind::eFollow:
-                ImGui::TextDisabled("Camera follows the target");
                 break;
         }
 
@@ -849,18 +816,11 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 if (ImGui::Checkbox("Rotation enabled##insp", &ui.rotation_enabled_insp)) {
                     insp->setRotationEnabled(ui.rotation_enabled_insp);
                 }
-                const char* rm_insp[] = {"Orbit (Euler)", "Trackball (Arcball)"};
-                if (ImGui::Combo("Rotation mode##insp_rm", &ui.rotation_mode_insp_idx, rm_insp, 2)) {
-                    insp->setRotationMode(ui.rotation_mode_insp_idx == 0
-                                              ? vne::interaction::OrbitalRotationMode::eOrbit
-                                              : vne::interaction::OrbitalRotationMode::eTrackball);
-                }
-                if (insp->getRotationMode() == vne::interaction::OrbitalRotationMode::eTrackball) {
+                {
                     using TPM = vne::interaction::TrackballProjectionMode;
-                    int proj_idx = (orb.getTrackballProjectionMode() == TPM::eHyperbolic) ? 0 : 1;
                     const char* proj_names[] = {"Hyperbolic", "Rim"};
-                    if (ImGui::Combo("Trackball projection##insp", &proj_idx, proj_names, 2)) {
-                        orb.setTrackballProjectionMode(proj_idx == 0 ? TPM::eHyperbolic : TPM::eRim);
+                    if (ImGui::Combo("Trackball projection##insp", &ui.trackball_proj_insp_idx, proj_names, 2)) {
+                        orb.setTrackballProjectionMode(ui.trackball_proj_insp_idx == 0 ? TPM::eHyperbolic : TPM::eRim);
                     }
                     ImGui::TextDisabled("Hyperbolic: cap + continuation; Rim: hemisphere + equatorial rim");
                 }
@@ -999,19 +959,6 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 float pd = opz.getPanDamping();
                 if (ImGui::SliderFloat("Pan damping##ortho", &pd, 0.f, 20.f)) {
                     opz.setPanDamping(pd);
-                }
-                ImGui::TreePop();
-            }
-        } else if (auto* follow = il.getFollowController()) {
-            if (ImGui::TreeNodeEx("Follow Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
-                vne::math::Vec3f off = follow->getOffset();
-                float o[3] = {off.x(), off.y(), off.z()};
-                if (ImGui::SliderFloat3("Offset##follow", o, -20.f, 20.f)) {
-                    follow->setOffset({o[0], o[1], o[2]});
-                }
-                float lag = follow->getLag();
-                if (ImGui::SliderFloat("Lag##follow", &lag, 0.01f, 0.5f, "%.3f")) {
-                    follow->setLag(lag);
                 }
                 ImGui::TreePop();
             }

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -1009,10 +1009,8 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                     using TPM = vne::interaction::TrackballProjectionMode;
                     const char* proj_names[] = {"Hyperbolic", "Rim"};
                     if (ImGui::Combo("Trackball projection##insp", &ui.trackball_proj_insp_idx, proj_names, 2)) {
-                        const auto proj =
-                            ui.trackball_proj_insp_idx == 0 ? TPM::eHyperbolic : TPM::eRim;
-                        forEachInspect(
-                            [&](auto& c) { c.trackballManipulator().setTrackballProjectionMode(proj); });
+                        const auto proj = ui.trackball_proj_insp_idx == 0 ? TPM::eHyperbolic : TPM::eRim;
+                        forEachInspect([&](auto& c) { c.trackballManipulator().setTrackballProjectionMode(proj); });
                     }
                     ImGui::TextDisabled("Hyperbolic: cap + continuation; Rim: hemisphere + equatorial rim");
                 }

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.cpp
@@ -1211,6 +1211,13 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 ImGui::TreePop();
             }
         } else if (auto* ortho = il.getOrtho2DController()) {
+            auto forEachOrtho = [&](auto&& fn) {
+                for (int i = 0; i < InteractionTestLayer::kMaxViewports; ++i) {
+                    if (auto* ctrl = il.getOrtho2DController(i)) {
+                        fn(*ctrl);
+                    }
+                }
+            };
             auto& opz = ortho->ortho2DManipulator();
             if (ImGui::TreeNodeEx("Ortho 2D Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
                 // View direction presets
@@ -1229,7 +1236,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 };
                 for (auto& vdp : vd_presets) {
                     if (ImGui::Button(vdp.label)) {
-                        ortho->setViewDirection(vdp.dir);
+                        forEachOrtho([&](auto& c) { c.setViewDirection(vdp.dir); });
                     }
                     ImGui::SameLine();
                 }
@@ -1237,21 +1244,21 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                 // DOF
                 bool rot_en = ortho->isRotationEnabled();
                 if (ImGui::Checkbox("Rotation enabled##ortho", &rot_en)) {
-                    ortho->setRotationEnabled(rot_en);
+                    forEachOrtho([&](auto& c) { c.setRotationEnabled(rot_en); });
                 }
                 // Pan inertia
                 ui.pan_inertia_enabled_ortho = opz.isPanInertiaEnabled();
                 if (ImGui::Checkbox("Pan inertia##ortho", &ui.pan_inertia_enabled_ortho)) {
-                    ortho->setPanInertiaEnabled(ui.pan_inertia_enabled_ortho);
+                    forEachOrtho([&](auto& c) { c.setPanInertiaEnabled(ui.pan_inertia_enabled_ortho); });
                 }
                 // Speeds
                 float zs = opz.getZoomSpeed();
                 if (ImGui::SliderFloat("Zoom speed##ortho", &zs, 1.01f, 1.5f, "%.3f")) {
-                    opz.setZoomSpeed(zs);
+                    forEachOrtho([&](auto& c) { c.ortho2DManipulator().setZoomSpeed(zs); });
                 }
                 float pd = opz.getPanDamping();
                 if (ImGui::SliderFloat("Pan damping##ortho", &pd, 0.f, 20.f)) {
-                    opz.setPanDamping(pd);
+                    forEachOrtho([&](auto& c) { c.ortho2DManipulator().setPanDamping(pd); });
                 }
                 ui.rotate_sensitivity_ortho = opz.getRotationSensitivityDegreesPerPixel();
                 if (ImGui::SliderFloat("Rotate sensitivity##ortho",
@@ -1259,7 +1266,7 @@ void InteractionSettingsLayer::renderManipulatorSettings() {
                                        0.05f,
                                        3.f,
                                        "%.2f deg/px")) {
-                    ortho->setRotateSensitivity(ui.rotate_sensitivity_ortho);
+                    forEachOrtho([&](auto& c) { c.setRotateSensitivity(ui.rotate_sensitivity_ortho); });
                 }
                 // World units per pixel readout
                 ImGui::Spacing();

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
@@ -57,6 +57,13 @@ enum class ControllerKind : int {
     eOrtho2D,
 };
 
+/** Governs what is reset when changing controller or projection type. */
+struct SwitchPolicy {
+    bool reset_scene_scale{true};   //!< Call setSceneScale(1.0f) before attaching new manipulators.
+    bool reset_rig_state{true};     //!< Call dispatchReset() before attaching to flush in-flight gestures.
+    bool reset_pose_to_default{false};  //!< Snap camera back to default position/target on switch.
+};
+
 using ControllerVariant = std::variant<vne::interaction::Inspect3DController,
                                        vne::interaction::Navigation3DController,
                                        vne::interaction::Ortho2DController>;
@@ -82,6 +89,9 @@ class InteractionTestLayer : public vne::testbed::ILayer {
 #ifdef VNE_TESTBED_IMGUI
     void setImGuiLayer(vne::testbed::ImGuiLayer* layer);
 #endif
+
+    void setSwitchPolicy(const SwitchPolicy& policy) noexcept { switch_policy_ = policy; }
+    [[nodiscard]] const SwitchPolicy& getSwitchPolicy() const noexcept { return switch_policy_; }
 
     void setControllerKind(ControllerKind kind);
     [[nodiscard]] ControllerKind getControllerKind() const noexcept { return current_kind_; }
@@ -124,6 +134,7 @@ class InteractionTestLayer : public vne::testbed::ILayer {
     void dispatchSetCamera(std::shared_ptr<vne::scene::ICamera> camera);
     void dispatchReset();
 
+    SwitchPolicy switch_policy_{};
     BaseSceneLayer* scene_layer_{nullptr};
     std::shared_ptr<vne::scene::ICamera> camera_;
     std::array<ControllerVariant, kMaxViewports> controllers_;
@@ -134,6 +145,7 @@ class InteractionTestLayer : public vne::testbed::ILayer {
     vne::interaction::FreeLookMode navigation_mode_{vne::interaction::FreeLookMode::eFps};
     double last_x_{0.0};
     double last_y_{0.0};
+    double last_frame_dt_{1.0 / 60.0};  //!< Real frame delta-time updated each onUpdate; used for inertia sampling.
 #ifdef VNE_TESTBED_IMGUI
     vne::testbed::ImGuiLayer* imgui_layer_{nullptr};
 #endif
@@ -153,11 +165,44 @@ struct InteractionUiSettings {
     float mouse_sensitivity{0.15f};
     float sprint_mult{4.0f};
     float slow_mult{0.2f};
+
+    // Inspect3D
     bool rotation_enabled_insp{true};
     /** Inspect3D trackball projection: 0 = Hyperbolic, 1 = Rim. */
     int trackball_proj_insp_idx{0};
     bool pan_enabled_insp{true};
     bool zoom_enabled_insp{true};
+    bool rotation_inertia_enabled_insp{true};
+    bool pan_inertia_enabled_insp{true};
+    bool orbit_animation_enabled_insp{true};
+    float fit_anim_duration_insp{0.5f};
+    float trackball_rotation_scale_insp{2.5f};
+    bool pivot_on_dbl_click_insp{true};
+
+    // Navigation3D
+    int nav_rotation_mode_idx{0};  //!< 0 = YawPitch, 1 = Trackball
+    bool look_enabled_nav{true};
+    bool move_enabled_nav{true};
+    bool zoom_enabled_nav{true};
+    int nav_world_up_idx{0};  //!< 0 = Y-up, 1 = Z-up
+
+    // Ortho2D
+    float rotate_sensitivity_ortho{0.5f};
+    bool pan_inertia_enabled_ortho{true};
+
+    // Camera state edit
+    int cam_edit_mode{0};  //!< 0 = LookAt, 1 = Pose (euler)
+    vne::math::Vec3f edit_pos{4.f, 3.f, 6.f};
+    vne::math::Vec3f edit_target{0.f, 0.f, 0.f};
+    vne::math::Vec3f edit_up{0.f, 1.f, 0.f};
+    float edit_yaw_deg{0.f};
+    float edit_pitch_deg{0.f};
+    float edit_roll_deg{0.f};
+
+    // On-switch policy
+    bool on_switch_reset_scene_scale{true};
+    bool on_switch_reset_rig_state{true};
+    bool on_switch_reset_pose{false};
 };
 
 class InteractionSettingsLayer : public vne::testbed::ILayer {

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
@@ -156,9 +156,9 @@ class InteractionTestLayer : public vne::testbed::ILayer {
 // ---------------------------------------------------------------------------
 #ifdef VNE_TESTBED_IMGUI
 // ImGui-tuned state (stable addresses for ImGui widgets).
+// Note: show_view_matrix / show_projection_matrix live in BaseSceneLayer::UiSettings so both
+// 02_test_scene and 03_test_interaction share the same field.
 struct InteractionUiSettings {
-    bool show_view_matrix{false};
-    bool show_projection_matrix{false};
     int zoom_idx{0};
     int nav_mode_idx{0};
     float move_speed{3.0f};

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
@@ -59,8 +59,8 @@ enum class ControllerKind : int {
 
 /** Governs what is reset when changing controller or projection type. */
 struct SwitchPolicy {
-    bool reset_scene_scale{true};   //!< Call setSceneScale(1.0f) before attaching new manipulators.
-    bool reset_rig_state{true};     //!< Call dispatchReset() before attaching to flush in-flight gestures.
+    bool reset_scene_scale{true};       //!< Call setSceneScale(1.0f) before attaching new manipulators.
+    bool reset_rig_state{true};         //!< Call dispatchReset() before attaching to flush in-flight gestures.
     bool reset_pose_to_default{false};  //!< Snap camera back to default position/target on switch.
 };
 

--- a/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
+++ b/samples/glfw_opengl/03_test_interaction/demo_test_interaction.h
@@ -18,7 +18,6 @@
 #include "vertexnova/interaction/inspect_3d_controller.h"
 #include "vertexnova/interaction/navigation_3d_controller.h"
 #include "vertexnova/interaction/ortho_2d_controller.h"
-#include "vertexnova/interaction/follow_controller.h"
 #include "vertexnova/interaction/interaction_types.h"
 
 #include "vertexnova/scene/camera/camera.h"
@@ -53,17 +52,14 @@ namespace vne::samples {
 
 /** Controller type for the interaction demo; maps to one of the high-level controllers. */
 enum class ControllerKind : int {
-    eInspectOrbit = 0,
-    eInspectTrackball,
+    eInspect3D = 0,
     eNavigation,  // FPS / Fly via setNavigationMode (FreeLookMode on Navigation3DController)
     eOrtho2D,
-    eFollow,
 };
 
 using ControllerVariant = std::variant<vne::interaction::Inspect3DController,
                                        vne::interaction::Navigation3DController,
-                                       vne::interaction::Ortho2DController,
-                                       vne::interaction::FollowController>;
+                                       vne::interaction::Ortho2DController>;
 
 // ---------------------------------------------------------------------------
 // InteractionTestLayer — owns camera + per-viewport controllers, exposes control API
@@ -120,7 +116,6 @@ class InteractionTestLayer : public vne::testbed::ILayer {
     [[nodiscard]] vne::interaction::Inspect3DController* getInspectController(int index = 0) noexcept;
     [[nodiscard]] vne::interaction::Navigation3DController* getNavController(int index = 0) noexcept;
     [[nodiscard]] vne::interaction::Ortho2DController* getOrtho2DController(int index = 0) noexcept;
-    [[nodiscard]] vne::interaction::FollowController* getFollowController(int index = 0) noexcept;
 
    private:
     void dispatchViewportSize(float w, float h);
@@ -132,7 +127,7 @@ class InteractionTestLayer : public vne::testbed::ILayer {
     BaseSceneLayer* scene_layer_{nullptr};
     std::shared_ptr<vne::scene::ICamera> camera_;
     std::array<ControllerVariant, kMaxViewports> controllers_;
-    ControllerKind current_kind_{ControllerKind::eInspectTrackball};
+    ControllerKind current_kind_{ControllerKind::eInspect3D};
 #ifdef VNE_TESTBED_IMGUI
     vne::testbed::MeshLayer* mesh_layer_{nullptr};
 #endif
@@ -159,7 +154,8 @@ struct InteractionUiSettings {
     float sprint_mult{4.0f};
     float slow_mult{0.2f};
     bool rotation_enabled_insp{true};
-    int rotation_mode_insp_idx{0};  // 0=Orbit 1=Trackball (Inspect3D)
+    /** Inspect3D trackball projection: 0 = Hyperbolic, 1 = Rim. */
+    int trackball_proj_insp_idx{0};
     bool pan_enabled_insp{true};
     bool zoom_enabled_insp{true};
 };

--- a/samples/glfw_opengl/common/base_scene_layer.cpp
+++ b/samples/glfw_opengl/common/base_scene_layer.cpp
@@ -129,12 +129,11 @@ void BaseSceneLayer::onRender(const vne::testbed::RenderContext& render_context)
                     half_x = std::max(half_x, max_abs_x);
                     half_y = std::max(half_y, max_abs_y);
                 }
-                const bool need_ortho_proj_sync =
-                    ui_settings_.show_grid
-                    || (vp_w != ortho_proj_sync_vp_w_ || vp_h != ortho_proj_sync_vp_h_
-                        || ui_settings_.ortho_half != ortho_proj_sync_half_
-                        || ui_settings_.ortho_near != ortho_proj_sync_near_
-                        || ui_settings_.ortho_far != ortho_proj_sync_far_);
+                const bool need_ortho_proj_sync = ui_settings_.show_grid
+                                                  || (vp_w != ortho_proj_sync_vp_w_ || vp_h != ortho_proj_sync_vp_h_
+                                                      || ui_settings_.ortho_half != ortho_proj_sync_half_
+                                                      || ui_settings_.ortho_near != ortho_proj_sync_near_
+                                                      || ui_settings_.ortho_far != ortho_proj_sync_far_);
                 if (need_ortho_proj_sync) {
                     o->setBounds(-half_x, half_x, -half_y, half_y, ui_settings_.ortho_near, ui_settings_.ortho_far);
                     o->updateProjectionMatrix();

--- a/samples/glfw_opengl/common/base_scene_layer.cpp
+++ b/samples/glfw_opengl/common/base_scene_layer.cpp
@@ -18,6 +18,9 @@
 #include "vertexnova/events/mouse_event.h"
 #include "vertexnova/events/window_event.h"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <string>
 
 namespace {
@@ -103,18 +106,37 @@ void BaseSceneLayer::onRender(const vne::testbed::RenderContext& render_context)
             if (auto* o = dynamic_cast<vne::scene::OrthographicCamera*>(camera)) {
                 const int vp_w = render_context.frame_info.width;
                 const int vp_h = render_context.frame_info.height;
-                const bool need_ortho_proj_sync = vp_w != ortho_proj_sync_vp_w_ || vp_h != ortho_proj_sync_vp_h_
-                                                  || ui_settings_.ortho_half != ortho_proj_sync_half_
-                                                  || ui_settings_.ortho_near != ortho_proj_sync_near_
-                                                  || ui_settings_.ortho_far != ortho_proj_sync_far_;
+                float half_y = ui_settings_.ortho_half;
+                float half_x = ui_settings_.ortho_half * aspect;
+                if (ui_settings_.show_grid) {
+                    // Expand orthographic extents so the full ground grid (XZ at y=0) stays inside the
+                    // frustum for any eye orientation — avoids clipping corners when ortho_half is small.
+                    const vne::math::Mat4f vm = o->getViewMatrix();
+                    float max_abs_x = 0.f;
+                    float max_abs_y = 0.f;
+                    const float g = kGridHalf;
+                    const std::array<vne::math::Vec3f, 4> corners = {
+                        vne::math::Vec3f{-g, 0.f, -g},
+                        vne::math::Vec3f{-g, 0.f, g},
+                        vne::math::Vec3f{g, 0.f, -g},
+                        vne::math::Vec3f{g, 0.f, g},
+                    };
+                    for (const auto& c : corners) {
+                        const vne::math::Vec4f p = vm * vne::math::Vec4f(c.x(), c.y(), c.z(), 1.f);
+                        max_abs_x = std::max(max_abs_x, std::fabs(p.x()));
+                        max_abs_y = std::max(max_abs_y, std::fabs(p.y()));
+                    }
+                    half_x = std::max(half_x, max_abs_x);
+                    half_y = std::max(half_y, max_abs_y);
+                }
+                const bool need_ortho_proj_sync =
+                    ui_settings_.show_grid
+                    || (vp_w != ortho_proj_sync_vp_w_ || vp_h != ortho_proj_sync_vp_h_
+                        || ui_settings_.ortho_half != ortho_proj_sync_half_
+                        || ui_settings_.ortho_near != ortho_proj_sync_near_
+                        || ui_settings_.ortho_far != ortho_proj_sync_far_);
                 if (need_ortho_proj_sync) {
-                    const float hw = ui_settings_.ortho_half * aspect;
-                    o->setBounds(-hw,
-                                 hw,
-                                 -ui_settings_.ortho_half,
-                                 ui_settings_.ortho_half,
-                                 ui_settings_.ortho_near,
-                                 ui_settings_.ortho_far);
+                    o->setBounds(-half_x, half_x, -half_y, half_y, ui_settings_.ortho_near, ui_settings_.ortho_far);
                     o->updateProjectionMatrix();
                     ortho_proj_sync_vp_w_ = vp_w;
                     ortho_proj_sync_vp_h_ = vp_h;
@@ -220,6 +242,10 @@ void BaseSceneLayer::syncCameraPositionTargetUp() {
 }
 
 void BaseSceneLayer::syncOrthoExtentsFromCamera() {
+    if (ui_settings_.show_grid) {
+        // Grid auto-fit inflates ortho bounds beyond ui_settings_.ortho_half; do not overwrite the slider.
+        return;
+    }
     auto* o = dynamic_cast<vne::scene::OrthographicCamera*>(getActiveCameraPtr(0));
     if (!o) {
         return;
@@ -230,6 +256,10 @@ void BaseSceneLayer::syncOrthoExtentsFromCamera() {
         // Align the dirty-guard cache so the next onRender doesn't immediately re-push the old value.
         ortho_proj_sync_half_ = live_half;
     }
+}
+
+void BaseSceneLayer::invalidateOrthoProjectionSync() {
+    ortho_proj_sync_vp_w_ = -1;
 }
 
 void BaseSceneLayer::rebuildCameras(int w, int h) {

--- a/samples/glfw_opengl/common/base_scene_layer.cpp
+++ b/samples/glfw_opengl/common/base_scene_layer.cpp
@@ -333,10 +333,7 @@ void BaseSceneLayer::drawAxes() const {
 
 BaseInteractionLayer::BaseInteractionLayer(const char* name)
     : vne::testbed::ILayer(name) {
-    controllers_.reserve(static_cast<size_t>(kMaxViewports));
-    for (int i = 0; i < kMaxViewports; ++i) {
-        controllers_.push_back(vne::interaction::Inspect3DController{});
-    }
+    controllers_.resize(static_cast<size_t>(kMaxViewports));
 }
 
 void BaseInteractionLayer::setCamera(std::shared_ptr<vne::scene::ICamera> camera) {

--- a/samples/glfw_opengl/common/base_scene_layer.cpp
+++ b/samples/glfw_opengl/common/base_scene_layer.cpp
@@ -284,9 +284,7 @@ BaseInteractionLayer::BaseInteractionLayer(const char* name)
     : vne::testbed::ILayer(name) {
     controllers_.reserve(static_cast<size_t>(kMaxViewports));
     for (int i = 0; i < kMaxViewports; ++i) {
-        vne::interaction::Inspect3DController c;
-        c.setRotationMode(vne::interaction::OrbitalRotationMode::eOrbit);
-        controllers_.push_back(std::move(c));
+        controllers_.push_back(vne::interaction::Inspect3DController{});
     }
 }
 

--- a/samples/glfw_opengl/common/base_scene_layer.cpp
+++ b/samples/glfw_opengl/common/base_scene_layer.cpp
@@ -75,6 +75,9 @@ void BaseSceneLayer::onUpdate(float /*dt*/) {
                 cam->updateMatrices();
             }
         }
+        // Keep ortho_half in sync with any interaction-driven bound changes so UI sliders
+        // always reflect the real zoom level and don't overwrite it on next slider touch.
+        syncOrthoExtentsFromCamera();
     }
 }
 
@@ -171,6 +174,10 @@ void BaseSceneLayer::setUsePerspective(bool use_persp) {
     if (ui_settings_.use_perspective == use_persp) {
         return;
     }
+    // Snapshot the live ortho extents before leaving ortho mode so we don't revert to stale UI values.
+    if (!ui_settings_.use_perspective) {
+        syncOrthoExtentsFromCamera();
+    }
     syncCameraPositionTargetUp();
     const vne::math::Vec3f pos = ui_settings_.cam_position;
     const vne::math::Vec3f tgt = ui_settings_.cam_target;
@@ -179,6 +186,7 @@ void BaseSceneLayer::setUsePerspective(bool use_persp) {
     if (ui_settings_.use_perspective) {
         for (auto& c : camera_persp_) {
             if (c) {
+                c->setSceneScale(1.0f);  // clear accumulated SceneScale zoom
                 c->setPosition(pos);
                 c->setTarget(tgt);
                 c->setUp(up);
@@ -188,6 +196,7 @@ void BaseSceneLayer::setUsePerspective(bool use_persp) {
     } else {
         for (auto& c : cameras_ortho_) {
             if (c) {
+                c->setSceneScale(1.0f);  // clear accumulated SceneScale zoom
                 c->setPosition(pos);
                 c->setTarget(tgt);
                 c->setUp(up);
@@ -208,6 +217,19 @@ void BaseSceneLayer::syncCameraPositionTargetUp() {
     ui_settings_.cam_position = active->getPosition();
     ui_settings_.cam_target = active->getTarget();
     ui_settings_.cam_up = active->getUp();
+}
+
+void BaseSceneLayer::syncOrthoExtentsFromCamera() {
+    auto* o = dynamic_cast<vne::scene::OrthographicCamera*>(getActiveCameraPtr(0));
+    if (!o) {
+        return;
+    }
+    const float live_half = o->getHeight() * 0.5f;
+    if (live_half > 0.0f) {
+        ui_settings_.ortho_half = live_half;
+        // Align the dirty-guard cache so the next onRender doesn't immediately re-push the old value.
+        ortho_proj_sync_half_ = live_half;
+    }
 }
 
 void BaseSceneLayer::rebuildCameras(int w, int h) {

--- a/samples/glfw_opengl/common/base_scene_layer.h
+++ b/samples/glfw_opengl/common/base_scene_layer.h
@@ -93,6 +93,8 @@ class BaseSceneLayer : public vne::testbed::ILayer {
     /** Reads the live orthographic half-extent back into ui_settings_.ortho_half so UI sliders
      *  stay in sync after interaction-driven zoom (manipulator calls setBounds on the ortho camera). */
     void syncOrthoExtentsFromCamera();
+    /** Forces the next onRender to re-apply orthographic bounds from ui_settings_ (after manual camera pose edits). */
+    void invalidateOrthoProjectionSync();
     void rebuildCameras(int w, int h);
 
    private:

--- a/samples/glfw_opengl/common/base_scene_layer.h
+++ b/samples/glfw_opengl/common/base_scene_layer.h
@@ -87,6 +87,9 @@ class BaseSceneLayer : public vne::testbed::ILayer {
 
     void setUsePerspective(bool use_persp);
     void syncCameraPositionTargetUp();
+    /** Reads the live orthographic half-extent back into ui_settings_.ortho_half so UI sliders
+     *  stay in sync after interaction-driven zoom (manipulator calls setBounds on the ortho camera). */
+    void syncOrthoExtentsFromCamera();
     void rebuildCameras(int w, int h);
 
    private:

--- a/samples/glfw_opengl/common/base_scene_layer.h
+++ b/samples/glfw_opengl/common/base_scene_layer.h
@@ -62,6 +62,9 @@ class BaseSceneLayer : public vne::testbed::ILayer {
         vne::math::Vec3f cam_position{4.0f, 3.0f, 6.0f};
         vne::math::Vec3f cam_target{0.0f, 0.0f, 0.0f};
         vne::math::Vec3f cam_up{0.0f, 1.0f, 0.0f};
+        // Debug overlays — shared naming with SceneUiSettings (02_test_scene).
+        bool show_view_matrix{false};
+        bool show_projection_matrix{false};
     };
 
     explicit BaseSceneLayer(const char* name = "BaseSceneLayer");

--- a/samples/glfw_opengl/common/base_scene_layer.h
+++ b/samples/glfw_opengl/common/base_scene_layer.h
@@ -110,7 +110,7 @@ class BaseSceneLayer : public vne::testbed::ILayer {
 };
 
 // ---------------------------------------------------------------------------
-// BaseInteractionLayer — orbit / trackball inspect driven by EventManager
+// BaseInteractionLayer — LMB trackball inspect (Inspect3DController) driven by EventManager
 // Pair with BaseSceneLayer: call setCamera(scene->getActiveCamera()) before attach.
 // Only compiled when VNE_TESTBED_INTERACTION is defined.
 // ---------------------------------------------------------------------------

--- a/scripts/clang_formatter.py
+++ b/scripts/clang_formatter.py
@@ -20,6 +20,7 @@ import argparse
 import os
 import subprocess
 import sys
+from functools import lru_cache
 from pathlib import Path
 
 
@@ -35,7 +36,7 @@ def find_source_files(folder_path: Path) -> list:
         # Recurse into all subdirs except excluded
         dirs[:] = [d for d in dirs if d not in exclude_dirs]
         for f in files:
-            if f.endswith(extensions):
+            if f.lower().endswith(extensions):
                 source_files.append(str(Path(root) / f))
 
     return source_files
@@ -47,6 +48,7 @@ def is_source_file(file_path: Path) -> bool:
     return file_path.suffix.lower() in extensions
 
 
+@lru_cache(maxsize=1)
 def get_clang_format_binary() -> str:
     """Use clang-format-17 when available (matches many VNE repos); otherwise clang-format."""
     for name in ('clang-format-17', 'clang-format'):
@@ -58,9 +60,8 @@ def get_clang_format_binary() -> str:
     return 'clang-format'  # fallback for error message
 
 
-def check_clang_format() -> bool:
+def check_clang_format(binary: str) -> bool:
     """Check if clang-format is available."""
-    binary = get_clang_format_binary()
     try:
         subprocess.run([binary, '--version'], capture_output=True, check=True)
         return True
@@ -68,13 +69,12 @@ def check_clang_format() -> bool:
         return False
 
 
-def run_clang_format(files: list, style_file: Path, dry_run: bool = False) -> bool:
+def run_clang_format(files: list, style_file: Path, dry_run: bool = False, *, binary: str) -> bool:
     """Run clang-format on the specified files."""
     if not files:
         print("No source files found to format.")
         return True
 
-    binary = get_clang_format_binary()
     print(f"Found {len(files)} source files to format (using {binary}).")
 
     base_cmd = [
@@ -87,7 +87,7 @@ def run_clang_format(files: list, style_file: Path, dry_run: bool = False) -> bo
         # Same as CI: fail if any file would be reformatted (--dry-run --Werror)
         print("DRY RUN - Checking for format violations (matches CI).")
         result = subprocess.run(
-            base_cmd + ['--dry-run', '--Werror'] + files,
+            [*base_cmd, '--dry-run', '--Werror', *files],
             capture_output=True,
             text=True,
         )
@@ -104,7 +104,7 @@ def run_clang_format(files: list, style_file: Path, dry_run: bool = False) -> bo
         print(f"Formatting: {file_path}")
         try:
             subprocess.run(
-                base_cmd + ['-i', file_path],
+                [*base_cmd, '-i', file_path],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -222,7 +222,7 @@ Examples:
 
     # Check clang-format availability (prefer clang-format-17 when present)
     binary = get_clang_format_binary()
-    if not check_clang_format():
+    if not check_clang_format(binary):
         print("Error: clang-format not found. Please install clang-format (install clang-format-17 for pinned behavior).")
         print("  Ubuntu/Debian: sudo apt install clang-format-17")
         print("  macOS: brew install clang-format@17  (or llvm)")
@@ -231,7 +231,7 @@ Examples:
         print(f"Note: Using '{binary}'. For CI-identical formatting when CI pins 17, install clang-format-17.")
 
     # Run clang-format
-    success = run_clang_format(source_files, style_file, args.dry_run)
+    success = run_clang_format(source_files, style_file, args.dry_run, binary=binary)
 
     if success:
         print("\n✓ Formatting completed successfully!")

--- a/scripts/clang_formatter.py
+++ b/scripts/clang_formatter.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
 """
-VneLogging Clang Formatter
-
-A generic script to format C/C++ source files using clang-format with
-VneLogging-specific formatting rules.
+Clang formatter for C/C++. Recursively finds C/C++ in given folders (same scope as CI).
 
 Usage:
-    python scripts/clang_formatter.py <folder_path> [options]
-    python scripts/clang_formatter.py --file <file_path> [options]
+    python scripts/clang_formatter.py <folder> [options]   # recursive under folder
+    python scripts/clang_formatter.py all [options]        # recursive under src, include, samples, tests
+    python scripts/clang_formatter.py --file <path> [options]
+
+  --dry-run  Check only (fail if any file needs formatting; matches CI).
+  Omit --dry-run to fix files in place.
 
 Examples:
-    python scripts/clang_formatter.py src/vnelogging
-    python scripts/clang_formatter.py src/vnelogging --dry-run
-    python scripts/clang_formatter.py src/vnelogging --verbose
-    python scripts/clang_formatter.py --file src/vertexnova/logging/logging.cpp
-    python scripts/clang_formatter.py --file include/vertexnova/logging/logging.h
+    python scripts/clang_formatter.py all --dry-run
+    python scripts/clang_formatter.py samples              # all subfolders under samples/
+    python scripts/clang_formatter.py --file samples/glfw_opengl/02_test_scene/demo_test_scene.cpp
 """
 
 import argparse
@@ -25,22 +24,19 @@ from pathlib import Path
 
 
 def find_source_files(folder_path: Path) -> list:
-    """Find all C/C++ source files in the specified folder."""
+    """Find all C/C++ source files recursively under the given folder."""
     source_files = []
+    root_path = Path(folder_path).resolve()
 
-    # Supported file extensions
     extensions = ('.h', '.cpp', '.mm', '.m', '.hpp', '.c')
-
-    # Directories to exclude
     exclude_dirs = {'build', '.git', 'node_modules', 'CMakeFiles', '__pycache__'}
 
-    for root, dirs, files in os.walk(folder_path):
-        # Remove excluded directories from dirs list to prevent walking into them
+    for root, dirs, files in os.walk(root_path, topdown=True):
+        # Recurse into all subdirs except excluded
         dirs[:] = [d for d in dirs if d not in exclude_dirs]
-
-        for file in files:
-            if file.endswith(extensions):
-                source_files.append(os.path.join(root, file))
+        for f in files:
+            if f.endswith(extensions):
+                source_files.append(str(Path(root) / f))
 
     return source_files
 
@@ -51,12 +47,22 @@ def is_source_file(file_path: Path) -> bool:
     return file_path.suffix.lower() in extensions
 
 
+def get_clang_format_binary() -> str:
+    """Use clang-format-17 when available (matches many VNE repos); otherwise clang-format."""
+    for name in ('clang-format-17', 'clang-format'):
+        try:
+            subprocess.run([name, '--version'], capture_output=True, check=True)
+            return name
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+    return 'clang-format'  # fallback for error message
+
+
 def check_clang_format() -> bool:
     """Check if clang-format is available."""
+    binary = get_clang_format_binary()
     try:
-        subprocess.run(['clang-format', '--version'],
-                      capture_output=True,
-                      check=True)
+        subprocess.run([binary, '--version'], capture_output=True, check=True)
         return True
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False
@@ -68,27 +74,41 @@ def run_clang_format(files: list, style_file: Path, dry_run: bool = False) -> bo
         print("No source files found to format.")
         return True
 
-    print(f"Found {len(files)} source files to format.")
+    binary = get_clang_format_binary()
+    print(f"Found {len(files)} source files to format (using {binary}).")
 
-    if dry_run:
-        print("DRY RUN - No files will be modified.")
-        return True
-
-    # Run clang-format on all files
-    cmd = [
-        'clang-format',
-        '-i',  # In-place formatting
-        '--style=file',  # Use .clang-format file
-        '--fallback-style=Google'  # Fallback style
+    base_cmd = [
+        binary,
+        '--style=file',
+        '--fallback-style=Google',
     ]
 
+    if dry_run:
+        # Same as CI: fail if any file would be reformatted (--dry-run --Werror)
+        print("DRY RUN - Checking for format violations (matches CI).")
+        result = subprocess.run(
+            base_cmd + ['--dry-run', '--Werror'] + files,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            if result.stderr:
+                print(result.stderr, file=sys.stderr)
+            print("One or more files need formatting. Run without --dry-run to fix.")
+            return False
+        print("All files are formatted correctly.")
+        return True
+
+    # In-place formatting
     for file_path in files:
         print(f"Formatting: {file_path}")
         try:
-            result = subprocess.run(cmd + [file_path],
-                                  capture_output=True,
-                                  text=True,
-                                  check=True)
+            subprocess.run(
+                base_cmd + ['-i', file_path],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
             print(f"  ✓ Formatted successfully")
         except subprocess.CalledProcessError as e:
             print(f"  ✗ Error formatting {file_path}: {e}")
@@ -105,16 +125,13 @@ def run_clang_format(files: list, style_file: Path, dry_run: bool = False) -> bo
 def main():
     """Main function."""
     parser = argparse.ArgumentParser(
-        description="Format C/C++ source files using clang-format with VneLogging rules",
+        description="Format C/C++ source files using clang-format (VneTestbed; CI dirs: src, include, samples, tests)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python scripts/clang_formatter.py src/vnelogging
-  python scripts/clang_formatter.py src/vnelogging --dry-run
-  python scripts/clang_formatter.py src/vnelogging --verbose
-  python scripts/clang_formatter.py tests
-  python scripts/clang_formatter.py --file src/vertexnova/logging/logging.cpp
-  python scripts/clang_formatter.py --file include/vertexnova/logging/logging.h
+  python scripts/clang_formatter.py all --dry-run
+  python scripts/clang_formatter.py samples
+  python scripts/clang_formatter.py --file samples/glfw_opengl/02_test_scene/demo_test_scene.cpp
         """
     )
 
@@ -123,11 +140,11 @@ Examples:
     group.add_argument(
         'folder',
         nargs='?',
-        help='Folder path to format (e.g., src/vnelogging)'
+        help='Folder to format (e.g. src, samples), or "all" for CI dirs (src, include, samples, tests)'
     )
     group.add_argument(
         '--file',
-        help='Specific file to format (e.g., src/vertexnova/logging/logging.cpp)'
+        help='Specific file to format (path relative to repo root)'
     )
 
     parser.add_argument(
@@ -153,7 +170,7 @@ Examples:
         print(f"Warning: .clang-format not found at {style_file}")
         print("Using fallback style: Google")
 
-    print("VneLogging Clang Formatter")
+    print("VneTestbed Clang Formatter")
     print("=" * 40)
     if style_file.exists():
         print(f"Style file: {style_file}")
@@ -178,18 +195,24 @@ Examples:
         source_files = [str(target_file)]
 
     else:
-        # Format folder
-        target_folder = project_root / args.folder
-
-        if not target_folder.exists():
-            print(f"Error: Target folder not found at {target_folder}")
-            sys.exit(1)
-
-        print(f"Target folder: {target_folder}")
+        # Format folder (or "all" = recursive over CI dirs: src, include, samples, tests)
+        if (args.folder or "").lower() in ("all", "ci"):
+            ci_dirs = ("src", "include", "samples", "tests")
+            source_files = []
+            for d in ci_dirs:
+                p = project_root / d
+                if p.is_dir():
+                    source_files.extend(find_source_files(p))  # recursive under each dir
+            source_files = sorted(set(source_files))
+            print(f"Target: CI dirs (recursive) src, include, samples, tests — {len(source_files)} files")
+        else:
+            target_folder = (project_root / args.folder).resolve()
+            if not target_folder.is_dir():
+                print(f"Error: Target folder not found at {target_folder}")
+                sys.exit(1)
+            print(f"Target folder (recursive): {target_folder}")
+            source_files = find_source_files(target_folder)
         print()
-
-        # Find source files
-        source_files = find_source_files(target_folder)
 
     if args.verbose:
         print("Source files found:")
@@ -197,12 +220,15 @@ Examples:
             print(f"  {file}")
         print()
 
-    # Check clang-format availability
+    # Check clang-format availability (prefer clang-format-17 when present)
+    binary = get_clang_format_binary()
     if not check_clang_format():
-        print("Error: clang-format not found. Please install clang-format.")
-        print("  Ubuntu/Debian: sudo apt install clang-format")
-        print("  macOS: brew install clang-format")
+        print("Error: clang-format not found. Please install clang-format (install clang-format-17 for pinned behavior).")
+        print("  Ubuntu/Debian: sudo apt install clang-format-17")
+        print("  macOS: brew install clang-format@17  (or llvm)")
         sys.exit(1)
+    if binary != 'clang-format-17':
+        print(f"Note: Using '{binary}'. For CI-identical formatting when CI pins 17, install clang-format-17.")
 
     # Run clang-format
     success = run_clang_format(source_files, style_file, args.dry_run)

--- a/scripts/clang_formatter.py
+++ b/scripts/clang_formatter.py
@@ -62,7 +62,6 @@ def get_clang_format_binary() -> str:
 
 def check_clang_format(binary: str) -> bool:
     """Check if clang-format is available."""
-    binary = get_clang_format_binary()
     try:
         subprocess.run([binary, '--version'], capture_output=True, check=True)
         return True

--- a/src/vertexnova/testbed/imgui/imgui_layer.cpp
+++ b/src/vertexnova/testbed/imgui/imgui_layer.cpp
@@ -489,11 +489,13 @@ void ImGuiLayer::renderSettingsPanel(const RenderContext& ctx) {
     if (!ImGui::Begin("Settings", nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
         const ImVec2 sp = ImGui::GetWindowPos();
         const ImVec2 ss = ImGui::GetWindowSize();
-        settings_screen_min_x_ = sp.x;
-        settings_screen_min_y_ = sp.y;
-        settings_screen_max_x_ = sp.x + ss.x;
-        settings_screen_max_y_ = sp.y + ss.y;
-        settings_window_rect_valid_ = true;
+        const auto rect = detail::makeSettingsWindowScreenRectWhenBeginSkipped(
+            ImGui::IsWindowCollapsed(), sp.x, sp.y, ss.x, ss.y);
+        settings_window_rect_valid_ = rect.valid;
+        settings_screen_min_x_ = rect.min_x;
+        settings_screen_min_y_ = rect.min_y;
+        settings_screen_max_x_ = rect.max_x;
+        settings_screen_max_y_ = rect.max_y;
         ImGui::End();
         return;
     }

--- a/src/vertexnova/testbed/imgui/imgui_layer.cpp
+++ b/src/vertexnova/testbed/imgui/imgui_layer.cpp
@@ -487,7 +487,13 @@ void ImGuiLayer::renderSettingsPanel(const RenderContext& ctx) {
     (void)ctx;
     // NoScrollbar on the outer window — we manage scrolling ourselves below.
     if (!ImGui::Begin("Settings", nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
-        settings_window_rect_valid_ = false;
+        const ImVec2 sp = ImGui::GetWindowPos();
+        const ImVec2 ss = ImGui::GetWindowSize();
+        settings_screen_min_x_ = sp.x;
+        settings_screen_min_y_ = sp.y;
+        settings_screen_max_x_ = sp.x + ss.x;
+        settings_screen_max_y_ = sp.y + ss.y;
+        settings_window_rect_valid_ = true;
         ImGui::End();
         return;
     }

--- a/src/vertexnova/testbed/imgui/imgui_layer.cpp
+++ b/src/vertexnova/testbed/imgui/imgui_layer.cpp
@@ -489,8 +489,8 @@ void ImGuiLayer::renderSettingsPanel(const RenderContext& ctx) {
     if (!ImGui::Begin("Settings", nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
         const ImVec2 sp = ImGui::GetWindowPos();
         const ImVec2 ss = ImGui::GetWindowSize();
-        const auto rect = detail::makeSettingsWindowScreenRectWhenBeginSkipped(
-            ImGui::IsWindowCollapsed(), sp.x, sp.y, ss.x, ss.y);
+        const auto rect =
+            detail::makeSettingsWindowScreenRectWhenBeginSkipped(ImGui::IsWindowCollapsed(), sp.x, sp.y, ss.x, ss.y);
         settings_window_rect_valid_ = rect.valid;
         settings_screen_min_x_ = rect.min_x;
         settings_screen_min_y_ = rect.min_y;

--- a/src/vertexnova/testbed/imgui/imgui_layer.cpp
+++ b/src/vertexnova/testbed/imgui/imgui_layer.cpp
@@ -487,8 +487,19 @@ void ImGuiLayer::renderSettingsPanel(const RenderContext& ctx) {
     (void)ctx;
     // NoScrollbar on the outer window — we manage scrolling ourselves below.
     if (!ImGui::Begin("Settings", nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
+        settings_window_rect_valid_ = false;
         ImGui::End();
         return;
+    }
+
+    {
+        const ImVec2 sp = ImGui::GetWindowPos();
+        const ImVec2 ss = ImGui::GetWindowSize();
+        settings_screen_min_x_ = sp.x;
+        settings_screen_min_y_ = sp.y;
+        settings_screen_max_x_ = sp.x + ss.x;
+        settings_screen_max_y_ = sp.y + ss.y;
+        settings_window_rect_valid_ = true;
     }
 
     // ---- Fixed header (always visible, not scrolled) -------------------------
@@ -653,6 +664,12 @@ int ImGuiLayer::getHoveredViewportIndex(float mouse_x, float mouse_y) const {
     float ix = mouse_x;
     float iy = mouse_y;
     clientMouseToImGuiScreen(ix, iy);
+    if (settings_window_rect_valid_) {
+        if (ix >= settings_screen_min_x_ && ix <= settings_screen_max_x_ && iy >= settings_screen_min_y_
+            && iy <= settings_screen_max_y_) {
+            return -1;
+        }
+    }
     const size_t n = viewport_rects_.size() / 4u;
     for (size_t i = 0; i < n; ++i) {
         const float min_x = viewport_rects_[i * 4u + 0u];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,10 @@ if(VNE_TESTBED_OPENGL OR VNE_TESTBED_OPENGLES)
     list(APPEND TEST_SOURCES window_test.cpp)
 endif()
 
+if(VNE_TESTBED_IMGUI_AVAILABLE)
+    list(APPEND TEST_SOURCES imgui_settings_rect_test.cpp)
+endif()
+
 #==============================================================================
 # Build test executable
 #==============================================================================

--- a/tests/imgui_settings_rect_test.cpp
+++ b/tests/imgui_settings_rect_test.cpp
@@ -1,0 +1,36 @@
+/* ---------------------------------------------------------------------
+ * Copyright (c) 2026 Ajeet Singh Yadav. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * Author:    Ajeet Singh Yadav
+ * Created:   March 2026
+ *
+ * Autodoc:   yes
+ * ----------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#ifdef VNE_TESTBED_IMGUI
+#include "vertexnova/testbed/imgui/imgui_layer.h"
+
+using vne::testbed::detail::makeSettingsWindowScreenRectWhenBeginSkipped;
+
+TEST(ImGuiSettingsRect, CollapsedWindowKeepsTitleBarRect) {
+    const auto rect = makeSettingsWindowScreenRectWhenBeginSkipped(true, 10.f, 20.f, 300.f, 24.f);
+    EXPECT_TRUE(rect.valid);
+    EXPECT_FLOAT_EQ(rect.min_x, 10.f);
+    EXPECT_FLOAT_EQ(rect.min_y, 20.f);
+    EXPECT_FLOAT_EQ(rect.max_x, 310.f);
+    EXPECT_FLOAT_EQ(rect.max_y, 44.f);
+}
+
+TEST(ImGuiSettingsRect, SkippedNonCollapsedWindowInvalidatesRect) {
+    const auto rect = makeSettingsWindowScreenRectWhenBeginSkipped(false, 0.f, 0.f, 1920.f, 1080.f);
+    EXPECT_FALSE(rect.valid);
+    EXPECT_FLOAT_EQ(rect.min_x, 0.f);
+    EXPECT_FLOAT_EQ(rect.min_y, 0.f);
+    EXPECT_FLOAT_EQ(rect.max_x, 0.f);
+    EXPECT_FLOAT_EQ(rect.max_y, 0.f);
+}
+#endif


### PR DESCRIPTION
## Description

<!-- Brief description of the change -->

**Release notes:** Use a [Conventional Commits](https://www.conventionalcommits.org/)–style PR title (e.g. `feat: add X`, `fix: resolve Y`, `docs: update Z`) so [release-please](https://github.com/googleapis/release-please) can include this change in the changelog. If you squash-merge, use the PR title as the commit message.

## Checklist

- [ ] Project builds (e.g. `cmake -B build` and `cmake --build build`, or platform script).
- [ ] Tests pass (e.g. `ctest --test-dir build` or script `-a test`).
- [ ] Code is formatted (e.g. run `clang-format` as configured for this repo); CI clang-format will check.
- [ ] Docs updated if you changed behavior or public API.

## Additional notes

<!-- Optional: migration notes, follow-up work, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer 3D inspection controls using trackball terminology.
  - Added configurable reset behavior when switching controllers.
  - Added optional view and projection matrix debug overlays.
  - Improved multi-viewport camera and manipulator synchronization.

- **Bug Fixes**
  - Prevented the Settings window from intercepting scene viewport interactions.
  - Improved orthographic framing so visible grids fit within the view automatically.
  - Preserved viewport dimensions and aspect ratios during camera resets.

- **Documentation**
  - Updated interaction sample documentation to reflect the available Inspect 3D, Navigation 3D, and Ortho 2D controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->